### PR TITLE
전시 조회 기능 추가 (#1)

### DIFF
--- a/src/main/java/com/hid_web/be/BeApplication.java
+++ b/src/main/java/com/hid_web/be/BeApplication.java
@@ -2,8 +2,9 @@ package com.hid_web.be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class BeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/hid_web/be/InitDB.java
+++ b/src/main/java/com/hid_web/be/InitDB.java
@@ -1,0 +1,74 @@
+package com.hid_web.be;
+
+import com.hid_web.be.domain.exhibit.ExhibitEntity;
+import com.hid_web.be.domain.exhibit.ExhibitArtistEntity;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class InitDB {
+    private final InitService initService;
+
+    @PostConstruct
+    public void init() {
+        initService.dbInit1();
+        initService.dbInit2();
+    }
+
+    @Component
+    @Transactional
+    @RequiredArgsConstructor
+    static class InitService {
+
+        private final EntityManager em;
+
+        public void dbInit1() {
+            ExhibitEntity exhibitEntity = new ExhibitEntity();
+            List<ExhibitArtistEntity> exhibitArtistEntities = new ArrayList<>();
+            ExhibitArtistEntity exhibitArtistEntityEntityKZ = new ExhibitArtistEntity();
+            exhibitArtistEntityEntityKZ.setName("Designer A");
+            exhibitArtistEntities.add(exhibitArtistEntityEntityKZ);
+
+            ExhibitArtistEntity exhibitArtistEntityEntityBM = new ExhibitArtistEntity();
+            exhibitArtistEntityEntityBM.setName("Designer B");
+            exhibitArtistEntities.add(exhibitArtistEntityEntityBM);
+
+            exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntities);
+            exhibitEntity.setText("홍익대학교 산업디자인학과 2024 여름 전시 - 1");
+            exhibitEntity.setImageUrl("전시 이미지 - 1");
+            exhibitEntity.setVideoUrl("전시 영상 - 1");
+
+            em.persist(exhibitEntity);
+        }
+
+        public void dbInit2() {
+            ExhibitEntity exhibitEntity = new ExhibitEntity();
+            List<ExhibitArtistEntity> exhibitArtistEntities = new ArrayList<>();
+
+            // 첫 번째 아티스트
+            ExhibitArtistEntity exhibitArtistEntityEntityJS = new ExhibitArtistEntity();
+            exhibitArtistEntityEntityJS.setName("Designer C");
+            exhibitArtistEntities.add(exhibitArtistEntityEntityJS);
+
+            // 두 번째 아티스트
+            ExhibitArtistEntity exhibitArtistEntityEntityYY = new ExhibitArtistEntity();
+            exhibitArtistEntityEntityYY.setName("Designer D");
+            exhibitArtistEntities.add(exhibitArtistEntityEntityYY);
+
+            exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntities);
+            exhibitEntity.setText("홍익대학교 산업디자인학과 2024 여름 전시 - 2");
+            exhibitEntity.setImageUrl("전시 이미지 - 2");
+            exhibitEntity.setVideoUrl("전시 영상 - 2");
+
+            em.persist(exhibitEntity);
+        }
+
+    }
+}

--- a/src/main/java/com/hid_web/be/controller/ExhibitController.java
+++ b/src/main/java/com/hid_web/be/controller/ExhibitController.java
@@ -1,0 +1,29 @@
+package com.hid_web.be.controller;
+
+import com.hid_web.be.controller.response.ExhibitResponse;
+import com.hid_web.be.domain.exhibit.ExhibitEntity;
+import com.hid_web.be.service.ExhibitService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/exhibit")
+@RequiredArgsConstructor
+@RestController
+public class ExhibitController {
+
+    private final ExhibitService exhibitService;
+
+    public void findAllExhibitPreview() {
+    }
+
+    @GetMapping("/{exhibitId}")
+    public ResponseEntity<ExhibitResponse> findExhibitById(@PathVariable Long exhibitId) {
+        // ResponseEntity<ExhibitDetailResponse>
+        ExhibitEntity exhibitEntity = exhibitService.findExhibitByExhibitId(exhibitId);
+        return ResponseEntity.ok().body(ExhibitResponse.of(exhibitEntity));
+    }
+}

--- a/src/main/java/com/hid_web/be/controller/response/ExhibitArtistResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitArtistResponse.java
@@ -1,0 +1,20 @@
+package com.hid_web.be.controller.response;
+
+import com.hid_web.be.domain.exhibit.ExhibitArtistEntity;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExhibitArtistResponse {
+    private String name; // 학생 이름
+
+    public static ExhibitArtistResponse of(ExhibitArtistEntity exhibitArtistEntity) {
+        return ExhibitArtistResponse.builder()
+                .name(exhibitArtistEntity.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/hid_web/be/controller/response/ExhibitResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitResponse.java
@@ -1,0 +1,32 @@
+package com.hid_web.be.controller.response;
+
+import com.hid_web.be.domain.exhibit.ExhibitEntity;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExhibitResponse {
+
+    private Long exhibitId; // 전시 번호
+    private List<ExhibitArtistResponse> exhibitArtistList; // 참여 학생 리스트
+    private String text; // 텍스트
+    private String imageUrl; // 이미지 URL
+    private String videoUrl; // 영상 URL
+
+    // ExhibitEntity를 ExhibitResponse로 변환하는 정적 팩토리 메서드
+    public static ExhibitResponse of(ExhibitEntity exhibitEntity) {
+        return ExhibitResponse.builder()
+                .exhibitId(exhibitEntity.getExhibitId())
+                .exhibitArtistList(exhibitEntity.getExhibitArtistEntityList().stream()
+                        .map(ea -> ExhibitArtistResponse.of(ea))
+                        .toList()) // 참여 학생 목록 변환
+                .text(exhibitEntity.getText())
+                .imageUrl(exhibitEntity.getImageUrl())
+                .videoUrl(exhibitEntity.getVideoUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitArtistEntity.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitArtistEntity.java
@@ -1,0 +1,22 @@
+package com.hid_web.be.domain.exhibit;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExhibitArtistEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name; // 학생 이름
+}

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitEntity.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitEntity.java
@@ -1,0 +1,28 @@
+package com.hid_web.be.domain.exhibit;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExhibitEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long exhibitId; // 전시 번호
+
+    @OneToMany(cascade=CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name="exhibit_id")
+    private List<ExhibitArtistEntity> exhibitArtistEntityList = new ArrayList<>(); // 참여 학생 리스트
+
+    private String text; // 텍스트
+    private String imageUrl; // 이미지 URL
+    private String videoUrl; // 영상 URL
+}

--- a/src/main/java/com/hid_web/be/repository/ExhibitRepository.java
+++ b/src/main/java/com/hid_web/be/repository/ExhibitRepository.java
@@ -1,0 +1,11 @@
+package com.hid_web.be.repository;
+
+import com.hid_web.be.domain.exhibit.ExhibitEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ExhibitRepository extends JpaRepository<ExhibitEntity, Long> {
+    List<ExhibitEntity> findAll();
+    ExhibitEntity findExhibitByExhibitId(Long exhibitId);
+}

--- a/src/main/java/com/hid_web/be/service/ExhibitService.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitService.java
@@ -1,0 +1,21 @@
+package com.hid_web.be.service;
+
+import com.hid_web.be.domain.exhibit.ExhibitEntity;
+import com.hid_web.be.repository.ExhibitRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ExhibitService {
+    private final ExhibitRepository exhibitRepository;
+
+    public void findAllExhibitPreview() {
+    }
+
+    public ExhibitEntity findExhibitByExhibitId(Long exhibitId) {
+        return exhibitRepository.findExhibitByExhibitId(exhibitId);
+    }
+}

--- a/src/main/java/com/hid_web/be/support/db/InitDCL.sql
+++ b/src/main/java/com/hid_web/be/support/db/InitDCL.sql
@@ -1,0 +1,23 @@
+-- MySQL 데이터베이스 서버에 연결
+USE mysql;
+
+-- 새로운 데이터베이스 'hid'를 생성
+CREATE DATABASE hid;
+
+-- 'hid'라는 이름의 새 사용자 'hid'를 생성하고 비밀번호를 'hid0326'으로 설정
+CREATE USER 'hid'@'%' IDENTIFIED BY 'hid0326';
+
+-- 새 사용자 'hid'에게 데이터베이스 'hid'의 모든 권한을 부여
+GRANT ALL PRIVILEGES ON hid.* TO 'hid'@'%';
+
+-- 권한 변경 사항을 즉시 적용
+FLUSH PRIVILEGES;
+
+-- 모든 데이터베이스 목록을 표시
+SHOW DATABASES;
+
+-- 데이터베이스 'hid'의 'exhibit_entity' 테이블에서 모든 데이터를 조회
+SELECT * FROM hid.exhibit_entity;
+
+-- 데이터베이스 'hid'의 'exhibit_artist_entity' 테이블에서 모든 데이터를 조회
+SELECT * FROM hid.exhibit_artist_entity;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,20 @@
 spring:
-  application:
-    name: be
+  datasource:
+    url: jdbc:mysql://localhost:3306/hid
+    username: hid
+    password: hid0326
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+        default_batch_fetch_size: 100
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type: trace


### PR DESCRIPTION
### Description
전시 도메인은 API Spec이 변화할 가능성이 많은 것을 고려하여 Presentation Layer에서 개념 객체를 DTO로 변환하여 반환하도록 한다.
전시에 참여할 디자이너 수가 둘 이상일 가능성이 많은 것을 고려하여 지연 로딩 성능 최적화를 위해 Fetch Size 글로벌 설정을 한다.

### Todo
Presentation Layer, Service Layer, Data Access Layer 구조로 패키지 추가
전시 엔티티 추가
전시 디자이너 엔티티 추가
전시 응답 DTO 추가
전시 디자이너 DTO 추가
Fetch Size 글로벌 설정 추가
MySQL 연동
전시 조회 API 구현

### Future Tasks
전시 엔티티 세부 정보(다수의 이미지 및 텍스트로 변경, 레이아웃과 연결 라벨, 영상 스트리밍 주소) 추가
전시 디자이너 엔티티 세부 정보(소셜 링크) 추가
Fetch Size 성능 테스트

closes #1