### PR TITLE
전시 프리뷰 전체 조회 기능 추가 (#3)

### DIFF
--- a/src/main/java/com/hid_web/be/InitDB.java
+++ b/src/main/java/com/hid_web/be/InitDB.java
@@ -33,6 +33,7 @@ public class InitDB {
             ExhibitEntity exhibitEntity = new ExhibitEntity();
             List<ExhibitArtistEntity> exhibitArtistEntities = new ArrayList<>();
             ExhibitArtistEntity exhibitArtistEntityEntityKZ = new ExhibitArtistEntity();
+
             exhibitArtistEntityEntityKZ.setName("Designer A");
             exhibitArtistEntities.add(exhibitArtistEntityEntityKZ);
 
@@ -45,6 +46,10 @@ public class InitDB {
             exhibitEntity.setImageUrl("전시 이미지 - 1");
             exhibitEntity.setVideoUrl("전시 영상 - 1");
 
+            exhibitEntity.setTitle("여름 전시 제목");
+            exhibitEntity.setSubtitle("여름 전시 부제");
+            exhibitEntity.setThumbnailUrl("대표 이미지");
+
             em.persist(exhibitEntity);
         }
 
@@ -52,12 +57,10 @@ public class InitDB {
             ExhibitEntity exhibitEntity = new ExhibitEntity();
             List<ExhibitArtistEntity> exhibitArtistEntities = new ArrayList<>();
 
-            // 첫 번째 아티스트
             ExhibitArtistEntity exhibitArtistEntityEntityJS = new ExhibitArtistEntity();
             exhibitArtistEntityEntityJS.setName("Designer C");
             exhibitArtistEntities.add(exhibitArtistEntityEntityJS);
 
-            // 두 번째 아티스트
             ExhibitArtistEntity exhibitArtistEntityEntityYY = new ExhibitArtistEntity();
             exhibitArtistEntityEntityYY.setName("Designer D");
             exhibitArtistEntities.add(exhibitArtistEntityEntityYY);
@@ -66,6 +69,10 @@ public class InitDB {
             exhibitEntity.setText("홍익대학교 산업디자인학과 2024 여름 전시 - 2");
             exhibitEntity.setImageUrl("전시 이미지 - 2");
             exhibitEntity.setVideoUrl("전시 영상 - 2");
+
+            exhibitEntity.setTitle("여름 전시 제목");
+            exhibitEntity.setSubtitle("여름 전시 부제");
+            exhibitEntity.setThumbnailUrl("대표 이미지");
 
             em.persist(exhibitEntity);
         }

--- a/src/main/java/com/hid_web/be/controller/ExhibitController.java
+++ b/src/main/java/com/hid_web/be/controller/ExhibitController.java
@@ -1,5 +1,6 @@
 package com.hid_web.be.controller;
 
+import com.hid_web.be.controller.response.ExhibitPreviewResponse;
 import com.hid_web.be.controller.response.ExhibitResponse;
 import com.hid_web.be.domain.exhibit.ExhibitEntity;
 import com.hid_web.be.service.ExhibitService;
@@ -10,14 +11,24 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/exhibit")
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequestMapping("/exhibits")
 @RequiredArgsConstructor
 @RestController
 public class ExhibitController {
 
     private final ExhibitService exhibitService;
 
-    public void findAllExhibitPreview() {
+    @GetMapping("/previews")
+    public ResponseEntity<List<ExhibitPreviewResponse>> findAllExhibitPreview() {
+        List<ExhibitEntity> exhibitEntityList = exhibitService.findAllExhibit();
+        List<ExhibitPreviewResponse> exhibitPreviewResponseList = exhibitEntityList.stream()
+                .map(e -> ExhibitPreviewResponse.of(e))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok().body(exhibitPreviewResponseList);
     }
 
     @GetMapping("/{exhibitId}")

--- a/src/main/java/com/hid_web/be/controller/response/ExhibitPreviewResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitPreviewResponse.java
@@ -1,0 +1,24 @@
+package com.hid_web.be.controller.response;
+
+import com.hid_web.be.domain.exhibit.ExhibitEntity;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExhibitPreviewResponse {
+    private Long exhibitId; // 전시 번호
+    private String title; // 제목
+    private String subtitle; // 부제
+    private String thumbnailUrl; // 썸네일 URL
+
+    public static ExhibitPreviewResponse of(ExhibitEntity exhibitEntity) {
+        return ExhibitPreviewResponse.builder()
+                .exhibitId(exhibitEntity.getExhibitId())
+                .title(exhibitEntity.getTitle())
+                .subtitle(exhibitEntity.getSubtitle())
+                .thumbnailUrl(exhibitEntity.getThumbnailUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitEntity.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitEntity.java
@@ -22,6 +22,9 @@ public class ExhibitEntity {
     @JoinColumn(name="exhibit_id")
     private List<ExhibitArtistEntity> exhibitArtistEntityList = new ArrayList<>(); // 참여 학생 리스트
 
+    private String title; // 제목
+    private String subtitle; // 부제
+    private String thumbnailUrl; // 썸네일 URL
     private String text; // 텍스트
     private String imageUrl; // 이미지 URL
     private String videoUrl; // 영상 URL

--- a/src/main/java/com/hid_web/be/service/ExhibitService.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitService.java
@@ -6,13 +6,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class ExhibitService {
     private final ExhibitRepository exhibitRepository;
 
-    public void findAllExhibitPreview() {
+    public List<ExhibitEntity> findAllExhibit() {
+        return exhibitRepository.findAll();
     }
 
     public ExhibitEntity findExhibitByExhibitId(Long exhibitId) {


### PR DESCRIPTION
### Description
전시를 클릭하여 상세 페이지로 넘어가기 전 모든 전시를 프리뷰 형식으로 한눈에 보여주려고 한다.

### Todo
전시 엔티티에 썸네일, 제목, 부제, 카테고리 속성 추가
전시 프리뷰 응답 DTO 추가
전시 프리뷰 전체 조회 API 구현

### Future Tasks
전시 수의 예측이 어려우므로 페이징 구현

closes #3 