### PR TITLE
S3 기반 대표 이미지 파일 저장 및 조회 기능 추가 (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Configuration Files
+application.yaml

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.2.0' // S3 연동
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/hid_web/be/controller/ExhibitController.java
+++ b/src/main/java/com/hid_web/be/controller/ExhibitController.java
@@ -4,22 +4,23 @@ import com.hid_web.be.controller.response.ExhibitPreviewResponse;
 import com.hid_web.be.controller.response.ExhibitResponse;
 import com.hid_web.be.domain.exhibit.ExhibitEntity;
 import com.hid_web.be.service.ExhibitService;
+import com.hid_web.be.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@RequestMapping("/exhibits")
-@RequiredArgsConstructor
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/exhibits")
 public class ExhibitController {
 
     private final ExhibitService exhibitService;
+    private final S3Service s3Service;
 
     @GetMapping("/previews")
     public ResponseEntity<List<ExhibitPreviewResponse>> findAllExhibitPreview() {
@@ -36,5 +37,18 @@ public class ExhibitController {
         // ResponseEntity<ExhibitDetailResponse>
         ExhibitEntity exhibitEntity = exhibitService.findExhibitByExhibitId(exhibitId);
         return ResponseEntity.ok().body(ExhibitResponse.of(exhibitEntity));
+    }
+
+    @PostMapping
+    public ResponseEntity<ExhibitResponse> createExhibitForTestOnlyThumbnail(@RequestParam("thumbnailImageFile") MultipartFile thumbnailImageFile) {
+        try {
+            String thumbnailUrl = s3Service.uploadThumbnail(thumbnailImageFile);
+
+            ExhibitEntity exhibitEntity = exhibitService.createExhibit(thumbnailUrl);
+
+            return ResponseEntity.ok().body(ExhibitResponse.of(exhibitEntity));
+        } catch (IOException e) {
+            return ResponseEntity.internalServerError().build();
+        }
     }
 }

--- a/src/main/java/com/hid_web/be/controller/response/ExhibitResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitResponse.java
@@ -13,6 +13,7 @@ public class ExhibitResponse {
 
     private Long exhibitId; // 전시 번호
     private List<ExhibitArtistResponse> exhibitArtistList; // 참여 학생 리스트
+    private String thumbnailUrl; // 참여 학생 리스트
     private String text; // 텍스트
     private String imageUrl; // 이미지 URL
     private String videoUrl; // 영상 URL
@@ -24,6 +25,7 @@ public class ExhibitResponse {
                 .exhibitArtistList(exhibitEntity.getExhibitArtistEntityList().stream()
                         .map(ea -> ExhibitArtistResponse.of(ea))
                         .toList()) // 참여 학생 목록 변환
+                .thumbnailUrl(exhibitEntity.getThumbnailUrl())
                 .text(exhibitEntity.getText())
                 .imageUrl(exhibitEntity.getImageUrl())
                 .videoUrl(exhibitEntity.getVideoUrl())

--- a/src/main/java/com/hid_web/be/service/ExhibitService.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitService.java
@@ -1,11 +1,13 @@
 package com.hid_web.be.service;
 
+import com.hid_web.be.domain.exhibit.ExhibitArtistEntity;
 import com.hid_web.be.domain.exhibit.ExhibitEntity;
 import com.hid_web.be.repository.ExhibitRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -20,5 +22,30 @@ public class ExhibitService {
 
     public ExhibitEntity findExhibitByExhibitId(Long exhibitId) {
         return exhibitRepository.findExhibitByExhibitId(exhibitId);
+    }
+
+    public ExhibitEntity createExhibit(String thumbnailUrl) {
+        ExhibitEntity exhibitEntity = new ExhibitEntity();
+        List<ExhibitArtistEntity> exhibitArtistEntities = new ArrayList<>();
+
+        ExhibitArtistEntity exhibitArtistEntityKZ = new ExhibitArtistEntity();
+
+        exhibitArtistEntityKZ.setName("테스트 디자이너 A");
+        exhibitArtistEntities.add(exhibitArtistEntityKZ);
+
+        ExhibitArtistEntity exhibitArtistEntityBM = new ExhibitArtistEntity();
+        exhibitArtistEntityBM.setName("테스트 디자이너 B");
+        exhibitArtistEntities.add(exhibitArtistEntityBM);
+
+        exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntities);
+
+        exhibitEntity.setTitle("테스트 제목");
+        exhibitEntity.setSubtitle("테스트 부제");
+        exhibitEntity.setThumbnailUrl(thumbnailUrl);
+        exhibitEntity.setText("테스트 설명");
+        exhibitEntity.setImageUrl("테스트 이미지");
+        exhibitEntity.setVideoUrl("테스트 영상");
+
+        return exhibitRepository.save(exhibitEntity);
     }
 }

--- a/src/main/java/com/hid_web/be/service/S3Service.java
+++ b/src/main/java/com/hid_web/be/service/S3Service.java
@@ -1,0 +1,31 @@
+package com.hid_web.be.service;
+
+
+import io.awspring.cloud.s3.S3Operations;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Operations s3Operations;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String uploadThumbnail(MultipartFile file) throws IOException {
+        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+        try (InputStream inputStream = file.getInputStream()) {
+            s3Operations.upload(bucketName, fileName, inputStream);
+        }
+        return "https://" + bucketName + ".s3.amazonaws.com/" + fileName; // S3 URL 생성
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,20 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100
 
+  cloud:
+    aws:
+      credentials:
+        access-key: # Credentials 주의
+
+        secret-key: # Credentials 주의
+      s3:
+        bucket: # Credentials 주의
+      region:
+        static: # Credentials 주의
+
 logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type: trace
+
+


### PR DESCRIPTION
### Description
이미지 서버인 S3로 이미지 파일을 업로드 및 다운로드하고 MySQL DB에 객체에 대한 키를 저장하기 위해 연동하려고 한다.

간단하게 대표 이미지 파일에 대해서만 기능을 적용하고 요구사항 변화에 따라 엔티티 수정 후 모든 이미지 파일에 대해 기능을 적용할 예정이다.

중복 파일명이 존재할 가능성이 많으므로 우선 파일명 앞에 UUID를 추가하여 저장하는데 이때, UUID를 팀마다 고유하게 적용할지 각 파일마다 고유하게 적용할지 추후 논의가 필요하지만 우선 각 파일마다 적용하는 것으로 한다.

### Todo
S3에 대표 이미지 파일 저장 API 구현

S3에서 대표 이미지 파일 조회하도록 전시 상세 조회 API 수정

### Future Tasks
모든 이미지 파일 S3에 저장 및 조회 기능 추가

closes #5