### PR TITLE
S3 기반 전시 영역 내 모든 이미지 파일 저장 및 조회 기능 추가 (#7)

### DIFF
--- a/src/main/java/com/hid_web/be/controller/response/ExhibitArtistResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitArtistResponse.java
@@ -10,7 +10,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExhibitArtistResponse {
-    private String name; // 학생 이름
+    private String name;
 
     public static ExhibitArtistResponse of(ExhibitArtistEntity exhibitArtistEntity) {
         return ExhibitArtistResponse.builder()

--- a/src/main/java/com/hid_web/be/controller/response/ExhibitPreviewResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitPreviewResponse.java
@@ -8,17 +8,17 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExhibitPreviewResponse {
-    private Long exhibitId; // 전시 번호
-    private String title; // 제목
-    private String subtitle; // 부제
-    private String thumbnailUrl; // 썸네일 URL
+    private Long exhibitId;
+    private String title;
+    private String subtitle;
+    private String thumbnailUrl;
 
     public static ExhibitPreviewResponse of(ExhibitEntity exhibitEntity) {
         return ExhibitPreviewResponse.builder()
                 .exhibitId(exhibitEntity.getExhibitId())
                 .title(exhibitEntity.getTitle())
                 .subtitle(exhibitEntity.getSubtitle())
-                .thumbnailUrl(exhibitEntity.getThumbnailUrl())
+                .thumbnailUrl(exhibitEntity.getMainThumbnailImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/hid_web/be/controller/response/ExhibitResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitResponse.java
@@ -11,12 +11,12 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExhibitResponse {
 
-    private Long exhibitId; // 전시 번호
-    private List<ExhibitArtistResponse> exhibitArtistList; // 참여 학생 리스트
-    private String thumbnailUrl; // 참여 학생 리스트
-    private String text; // 텍스트
-    private String imageUrl; // 이미지 URL
-    private String videoUrl; // 영상 URL
+    private Long exhibitId;
+    private List<ExhibitArtistResponse> exhibitArtistList;
+    private String thumbnailUrl;
+    private String text;
+    private String imageUrl;
+    private String videoUrl;
 
     // ExhibitEntity를 ExhibitResponse로 변환하는 정적 팩토리 메서드
     public static ExhibitResponse of(ExhibitEntity exhibitEntity) {
@@ -24,8 +24,8 @@ public class ExhibitResponse {
                 .exhibitId(exhibitEntity.getExhibitId())
                 .exhibitArtistList(exhibitEntity.getExhibitArtistEntityList().stream()
                         .map(ea -> ExhibitArtistResponse.of(ea))
-                        .toList()) // 참여 학생 목록 변환
-                .thumbnailUrl(exhibitEntity.getThumbnailUrl())
+                        .toList())
+                .thumbnailUrl(exhibitEntity.getMainThumbnailImageUrl())
                 .text(exhibitEntity.getText())
                 .imageUrl(exhibitEntity.getImageUrl())
                 .videoUrl(exhibitEntity.getVideoUrl())

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitAdditionalThumbnailEntity.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitAdditionalThumbnailEntity.java
@@ -12,11 +12,13 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class ExhibitArtistEntity {
+public class ExhibitAdditionalThumbnailEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
+    private String additionalThumbnailImageUrl;
+
+    private int position;
 }

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitDetailImageEntity.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitDetailImageEntity.java
@@ -12,11 +12,15 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class ExhibitArtistEntity {
+public class ExhibitDetailImageEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
+    private String detailImageUrl;
+
+    private int position;
 }
+
+

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitEntity.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitEntity.java
@@ -16,16 +16,25 @@ public class ExhibitEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long exhibitId; // 전시 번호
+    private Long exhibitId;
 
     @OneToMany(cascade=CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name="exhibit_id")
-    private List<ExhibitArtistEntity> exhibitArtistEntityList = new ArrayList<>(); // 참여 학생 리스트
+    private List<ExhibitArtistEntity> exhibitArtistEntityList = new ArrayList<>();
 
-    private String title; // 제목
-    private String subtitle; // 부제
-    private String thumbnailUrl; // 썸네일 URL
-    private String text; // 텍스트
-    private String imageUrl; // 이미지 URL
-    private String videoUrl; // 영상 URL
+    private String mainThumbnailImageUrl;
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "exhibit_id")
+    private List<ExhibitAdditionalThumbnailEntity> additionalThumbnails = new ArrayList<>();
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "exhibit_id")
+    private List<ExhibitDetailImageEntity> detailImages = new ArrayList<>();
+
+    private String title;
+    private String subtitle;
+    private String text;
+    private String imageUrl;
+    private String videoUrl;
 }

--- a/src/main/java/com/hid_web/be/service/ExhibitArtistWriter.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitArtistWriter.java
@@ -1,0 +1,24 @@
+package com.hid_web.be.service;
+
+import com.hid_web.be.domain.exhibit.ExhibitArtistEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class ExhibitArtistWriter {
+
+    public List<ExhibitArtistEntity> createArtistList(List<String> artistNames) {
+        List<ExhibitArtistEntity> exhibitArtistEntities = new ArrayList<>();
+
+        for (String name : artistNames) {
+            ExhibitArtistEntity artistEntity = new ExhibitArtistEntity();
+            artistEntity.setName(name);
+            exhibitArtistEntities.add(artistEntity);
+        }
+
+        return exhibitArtistEntities;
+    }
+}
+

--- a/src/main/java/com/hid_web/be/service/ExhibitReader.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitReader.java
@@ -1,0 +1,23 @@
+package com.hid_web.be.service;
+
+import com.hid_web.be.domain.exhibit.ExhibitEntity;
+import com.hid_web.be.repository.ExhibitRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ExhibitReader {
+
+    private final ExhibitRepository exhibitRepository;
+
+    public List<ExhibitEntity> findAllExhibit() {
+        return exhibitRepository.findAll();
+    }
+
+    public ExhibitEntity findExhibitById(Long exhibitId) {
+        return exhibitRepository.findExhibitByExhibitId(exhibitId);
+    }
+}

--- a/src/main/java/com/hid_web/be/service/ExhibitWriter.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitWriter.java
@@ -1,0 +1,65 @@
+package com.hid_web.be.service;
+
+import com.hid_web.be.domain.exhibit.ExhibitAdditionalThumbnailEntity;
+import com.hid_web.be.domain.exhibit.ExhibitArtistEntity;
+import com.hid_web.be.domain.exhibit.ExhibitDetailImageEntity;
+import com.hid_web.be.domain.exhibit.ExhibitEntity;
+import com.hid_web.be.repository.ExhibitRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ExhibitWriter {
+
+    private final ExhibitRepository exhibitRepository;
+    private final ExhibitArtistWriter exhibitArtistWriter;
+
+    public ExhibitEntity createExhibit(String mainThumbnailImageUrl,
+                                       String title,
+                                       String subtitle,
+                                       String text,
+                                       String imageUrl,
+                                       String videoUrl,
+                                       List<String> additionalThumbnailImageUrls,
+                                       List<String> detailImageUrls,
+                                       List<String> artistNames) {
+
+        ExhibitEntity exhibitEntity = new ExhibitEntity();
+
+        List<ExhibitArtistEntity> exhibitArtistEntities = exhibitArtistWriter.createArtistList(artistNames);
+        exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntities);
+
+        exhibitEntity.setTitle(title);
+        exhibitEntity.setSubtitle(subtitle);
+        exhibitEntity.setMainThumbnailImageUrl(mainThumbnailImageUrl);
+        exhibitEntity.setText(text);
+        exhibitEntity.setImageUrl(imageUrl);
+        exhibitEntity.setVideoUrl(videoUrl);
+
+        List<ExhibitAdditionalThumbnailEntity> additionalThumbnails = new ArrayList<>();
+        for (int i = 0; i < additionalThumbnailImageUrls.size(); i++) {
+            ExhibitAdditionalThumbnailEntity additionalThumbnail = new ExhibitAdditionalThumbnailEntity();
+            additionalThumbnail.setAdditionalThumbnailImageUrl(additionalThumbnailImageUrls.get(i));
+            additionalThumbnail.setPosition(i + 1);
+            additionalThumbnails.add(additionalThumbnail);
+        }
+        exhibitEntity.setAdditionalThumbnails(additionalThumbnails);
+
+        List<ExhibitDetailImageEntity> detailImages = new ArrayList<>();
+        for (int i = 0; i < detailImageUrls.size(); i++) {
+            ExhibitDetailImageEntity detailImage = new ExhibitDetailImageEntity();
+            detailImage.setDetailImageUrl(detailImageUrls.get(i));
+            detailImage.setPosition(i + 1);
+            detailImages.add(detailImage);
+        }
+        exhibitEntity.setDetailImages(detailImages);
+
+        return exhibitRepository.save(exhibitEntity);
+    }
+}
+

--- a/src/main/java/com/hid_web/be/service/S3Writer.java
+++ b/src/main/java/com/hid_web/be/service/S3Writer.java
@@ -1,0 +1,52 @@
+package com.hid_web.be.service;
+
+import io.awspring.cloud.s3.S3Operations;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class S3Writer {
+
+    private final S3Operations s3Operations;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String writeFile(MultipartFile file, String folderPath) throws IOException {
+        return uploadSingleFile(file, folderPath);
+    }
+
+    public List<String> writeFiles(List<MultipartFile> files, String folderPath) throws IOException {
+        List<String> urls = new ArrayList<>();
+        if (files != null && !files.isEmpty()) {
+            for (MultipartFile file : files) {
+                urls.add(uploadSingleFile(file, folderPath));
+            }
+        }
+        return urls;
+    }
+
+    public String uploadSingleFile(MultipartFile file, String folderPath) throws IOException {
+        String objectKey = folderPath + "/" + file.getOriginalFilename();
+
+        try (InputStream inputStream = file.getInputStream()) {
+            s3Operations.upload(bucketName, objectKey, inputStream);
+        }
+
+        return generateFileUrl(objectKey);
+    }
+
+    public String generateFileUrl(String objectKey) {
+        return "https://" + bucketName + ".s3.amazonaws.com/" + objectKey;
+    }
+
+}
+


### PR DESCRIPTION
### Description
이미지 서버인 S3로 이미지 파일을 업로드 및 다운로드하고 MySQL DB에 객체에 대한 키를 저장하기 위해 연동하려고 한다.

이전엔 대표 이미지 파일에 대해서만 적용했지만 확장하여 전시에 나타날 작은 대표 이미지, 상세 이미지에 대해서도 기능을 확장하려고 한다.

S3에 설계하려는 게층 구조에 따라 저장되도록 하는 것이 목표이다.

이미지 파일들의 순서가 중요하므로 프론트엔드 측에서 미리 파일명을 지정하여 넘겨주면 파일명의 순서에 따라 저장한다.

추후에 관리자에 의해 이미지 파일의 순서가 바뀔 수 있다는 부분을 고려하여 DB에도 순서를 기록하여야 한다.

### Todo
S3에 작은 대표 이미지, 상세 이미지 파일 저장 API 구현

S3에서 대표 이미지 파일 조회하도록 전시 상세 조회 API 수정

### Future
각 팀원마다 프로필 이미지 파일이 존재하는데 전시 참여 아티스트 엔티티에 존재하므로 추후에 확장하려고 한다.

closes #7 