### PR TITLE
S3 기반 전시 참여 아티스트 영역 내 프로필 이미지 파일 저장 및 조회 기능 추가 (#9)

### DIFF
--- a/src/main/java/com/hid_web/be/InitDB.java
+++ b/src/main/java/com/hid_web/be/InitDB.java
@@ -48,7 +48,7 @@ public class InitDB {
 
             exhibitEntity.setTitle("여름 전시 제목");
             exhibitEntity.setSubtitle("여름 전시 부제");
-            exhibitEntity.setThumbnailUrl("대표 이미지");
+            exhibitEntity.setMainThumbnailImageUrl("대표 이미지");
 
             em.persist(exhibitEntity);
         }
@@ -72,7 +72,7 @@ public class InitDB {
 
             exhibitEntity.setTitle("여름 전시 제목");
             exhibitEntity.setSubtitle("여름 전시 부제");
-            exhibitEntity.setThumbnailUrl("대표 이미지");
+            exhibitEntity.setMainThumbnailImageUrl("대표 이미지");
 
             em.persist(exhibitEntity);
         }

--- a/src/main/java/com/hid_web/be/controller/ExhibitController.java
+++ b/src/main/java/com/hid_web/be/controller/ExhibitController.java
@@ -38,12 +38,13 @@ public class ExhibitController {
 
     @PostMapping
     public ResponseEntity<ExhibitResponse> createExhibit(
-            @RequestParam("mainThumbnailImageFile") MultipartFile mainThumbnailImageFile,
+            @RequestParam(value = "mainThumbnailImageFile") MultipartFile mainThumbnailImageFile,
             @RequestParam(value = "additionalThumbnailImageFiles", required = false) List<MultipartFile> additionalThumbnailImageFiles,
-            @RequestParam(value = "detailImageFiles", required = false) List<MultipartFile> detailImageFiles) {
+            @RequestParam(value = "detailImageFiles") List<MultipartFile> detailImageFiles,
+            @RequestParam(value = "profileImageFiles") List<MultipartFile> profileImageFiles) {
 
         try {
-            ExhibitEntity exhibitEntity = exhibitService.createExhibit(mainThumbnailImageFile, additionalThumbnailImageFiles, detailImageFiles);
+            ExhibitEntity exhibitEntity = exhibitService.createExhibit(mainThumbnailImageFile, additionalThumbnailImageFiles, detailImageFiles, profileImageFiles);
 
             return ResponseEntity.ok(ExhibitResponse.of(exhibitEntity));
         } catch (IOException e) {

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitArtistEntity.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitArtistEntity.java
@@ -19,4 +19,6 @@ public class ExhibitArtistEntity {
     private Long id;
 
     private String name;
+
+    private String profileImageUrl;
 }

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitEntity.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitEntity.java
@@ -26,7 +26,7 @@ public class ExhibitEntity {
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "exhibit_id")
-    private List<ExhibitAdditionalThumbnailEntity> additionalThumbnails = new ArrayList<>();
+    private List<ExhibitAdditionalThumbnailEntity> additionalThumbnailImages = new ArrayList<>();
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "exhibit_id")

--- a/src/main/java/com/hid_web/be/service/ExhibitExtractor.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitExtractor.java
@@ -1,0 +1,44 @@
+package com.hid_web.be.service;
+
+import org.springframework.stereotype.Service;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class ExhibitExtractor {
+
+    public List<String> extractArtistNamesFromUrls(List<String> profileImageUrls) {
+        List<String> artistNames = new ArrayList<>();
+
+        for (String url : profileImageUrls) {
+            String fileName = url.substring(url.lastIndexOf('/') + 1);
+            String fileNameWithoutExtension = fileName.substring(0, fileName.lastIndexOf('.'));
+            String artistName = fileNameWithoutExtension.replace("_", " ");
+            artistNames.add(artistName);
+        }
+
+        return artistNames;
+    }
+
+    public Map<Integer, String> extractUrlMapWithPosition(List<String> imageUrls) {
+        Map<Integer, String> urlMap = new HashMap<>();
+
+        for (String url : imageUrls) {
+            int position = extractPositionFromFilename(url);
+            urlMap.put(position, url);
+        }
+
+        return urlMap;
+    }
+
+    public int extractPositionFromFilename(String fileName) {
+        String positionStr = fileName.substring(fileName.lastIndexOf("_") + 1, fileName.lastIndexOf('.'));
+        int position = Integer.parseInt(positionStr);
+
+        return position;
+    }
+}
+
+

--- a/src/main/java/com/hid_web/be/service/ExhibitService.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitService.java
@@ -1,6 +1,5 @@
 package com.hid_web.be.service;
 
-import com.hid_web.be.controller.response.ExhibitResponse;
 import com.hid_web.be.domain.exhibit.ExhibitEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @Slf4j
@@ -17,6 +17,7 @@ public class ExhibitService {
     private final S3Writer s3Writer;
     private final ExhibitWriter exhibitWriter;
     private final ExhibitReader exhibitReader;
+    private final ExhibitExtractor exhibitExtractor;
 
     public List<ExhibitEntity> findAllExhibit() {
         return exhibitReader.findAllExhibit();
@@ -27,22 +28,29 @@ public class ExhibitService {
     }
 
     public ExhibitEntity createExhibit(MultipartFile mainThumbnailImageFile,
-                                         List<MultipartFile> additionalThumbnailImageFiles,
-                                         List<MultipartFile> detailImageFiles) throws IOException {
+                                       List<MultipartFile> additionalThumbnailImageFiles,
+                                       List<MultipartFile> detailImageFiles,
+                                       List<MultipartFile> profileImageFiles) throws IOException {
 
-        String mainThumbnailImageUrl = s3Writer.writeFile(mainThumbnailImageFile, "main-thumbnail");
-        List<String> additionalThumbnailImageUrls = s3Writer.writeFiles(additionalThumbnailImageFiles, "additional-thumbnails");
+        String mainThumbnailImageUrl = s3Writer.writeFile(mainThumbnailImageFile, "main-thumbnail-image");
+        List<String> additionalThumbnailImageUrls = s3Writer.writeFiles(additionalThumbnailImageFiles, "additional-thumbnails-images");
         List<String> detailImageUrls = s3Writer.writeFiles(detailImageFiles, "detail-images");
+        List<String> profileImageUrls = s3Writer.writeFiles(profileImageFiles, "profile-images");
 
-        List<String> artistNames = List.of("테스트 디자이너 A", "테스트 디자이너 B");
+        Map<Integer, String> additionalThumbnailImageMap = exhibitExtractor.extractUrlMapWithPosition(additionalThumbnailImageUrls);
+        Map<Integer, String> detailImageMap = exhibitExtractor.extractUrlMapWithPosition(detailImageUrls);
+
+        List<String> artistNames = exhibitExtractor.extractArtistNamesFromUrls(profileImageUrls);
 
         ExhibitEntity exhibitEntity = exhibitWriter.createExhibit(
                 mainThumbnailImageUrl,
-                "테스트 제목", "테스트 부제",
-                "테스트 설명", "테스트 이미지",
-                "테스트 영상", additionalThumbnailImageUrls,
-                detailImageUrls, artistNames
-        );
+                additionalThumbnailImageMap, detailImageMap,
+                "테스트 제목",
+                "테스트 부제",
+                "테스트 설명",
+                "테스트 이미지",
+                "테스트 영상",
+                profileImageUrls, artistNames);
 
         return exhibitEntity;
     }

--- a/src/main/java/com/hid_web/be/service/ExhibitWriter.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitWriter.java
@@ -6,60 +6,79 @@ import com.hid_web.be.domain.exhibit.ExhibitDetailImageEntity;
 import com.hid_web.be.domain.exhibit.ExhibitEntity;
 import com.hid_web.be.repository.ExhibitRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class ExhibitWriter {
 
     private final ExhibitRepository exhibitRepository;
-    private final ExhibitArtistWriter exhibitArtistWriter;
 
     public ExhibitEntity createExhibit(String mainThumbnailImageUrl,
+                                       Map<Integer, String> additionalThumbnailImageMap,
+                                       Map<Integer, String> detailImageMap,
                                        String title,
                                        String subtitle,
                                        String text,
                                        String imageUrl,
                                        String videoUrl,
-                                       List<String> additionalThumbnailImageUrls,
-                                       List<String> detailImageUrls,
+                                       List<String> profileImageUrls,
                                        List<String> artistNames) {
 
         ExhibitEntity exhibitEntity = new ExhibitEntity();
 
-        List<ExhibitArtistEntity> exhibitArtistEntities = exhibitArtistWriter.createArtistList(artistNames);
-        exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntities);
+
+        exhibitEntity.setMainThumbnailImageUrl(mainThumbnailImageUrl);
+
+        List<ExhibitAdditionalThumbnailEntity> additionalThumbnails = new ArrayList<>();
+        for (Map.Entry<Integer, String> entry : additionalThumbnailImageMap.entrySet()) {
+            ExhibitAdditionalThumbnailEntity additionalThumbnail = new ExhibitAdditionalThumbnailEntity();
+            additionalThumbnail.setPosition(entry.getKey());
+            additionalThumbnail.setAdditionalThumbnailImageUrl(entry.getValue());
+            additionalThumbnails.add(additionalThumbnail);
+        }
+
+        List<ExhibitDetailImageEntity> detailImages = new ArrayList<>();
+        for (Map.Entry<Integer, String> entry : detailImageMap.entrySet()) {
+            ExhibitDetailImageEntity detailImage = new ExhibitDetailImageEntity();
+            detailImage.setPosition(entry.getKey());
+            detailImage.setDetailImageUrl(entry.getValue());
+            detailImages.add(detailImage);
+        }
+
+        exhibitEntity.setMainThumbnailImageUrl(mainThumbnailImageUrl);
+        exhibitEntity.setAdditionalThumbnailImages(additionalThumbnails);
+        exhibitEntity.setDetailImages(detailImages);
 
         exhibitEntity.setTitle(title);
         exhibitEntity.setSubtitle(subtitle);
-        exhibitEntity.setMainThumbnailImageUrl(mainThumbnailImageUrl);
         exhibitEntity.setText(text);
         exhibitEntity.setImageUrl(imageUrl);
         exhibitEntity.setVideoUrl(videoUrl);
 
-        List<ExhibitAdditionalThumbnailEntity> additionalThumbnails = new ArrayList<>();
-        for (int i = 0; i < additionalThumbnailImageUrls.size(); i++) {
-            ExhibitAdditionalThumbnailEntity additionalThumbnail = new ExhibitAdditionalThumbnailEntity();
-            additionalThumbnail.setAdditionalThumbnailImageUrl(additionalThumbnailImageUrls.get(i));
-            additionalThumbnail.setPosition(i + 1);
-            additionalThumbnails.add(additionalThumbnail);
-        }
-        exhibitEntity.setAdditionalThumbnails(additionalThumbnails);
+        List<ExhibitArtistEntity> exhibitArtistEntities = new ArrayList<>();
 
-        List<ExhibitDetailImageEntity> detailImages = new ArrayList<>();
-        for (int i = 0; i < detailImageUrls.size(); i++) {
-            ExhibitDetailImageEntity detailImage = new ExhibitDetailImageEntity();
-            detailImage.setDetailImageUrl(detailImageUrls.get(i));
-            detailImage.setPosition(i + 1);
-            detailImages.add(detailImage);
+        for (int i = 0; i < artistNames.size(); i++) {
+            ExhibitArtistEntity artistEntity = new ExhibitArtistEntity();
+
+            artistEntity.setName(artistNames.get(i));
+
+            if (i < profileImageUrls.size()) {
+                artistEntity.setProfileImageUrl(profileImageUrls.get(i));
+            }
+
+            exhibitArtistEntities.add(artistEntity);
         }
-        exhibitEntity.setDetailImages(detailImages);
+        exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntities);
+
+
 
         return exhibitRepository.save(exhibitEntity);
     }
 }
+
 


### PR DESCRIPTION
### Description
이미지 서버인 S3로 이미지 파일을 업로드 및 다운로드하고 MySQL DB에 객체에 대한 키를 저장하기 위해 연동하려고 한다.

이전엔 전시 영역의 이미지 파일에 대해서 적용했지만 전시 참여 아티스트 영역에 대해서도 기능을 확장하려고 한다.

이미지 파일명으로부터 아티스트의 이름을 추출하는 로직을 넣어 이름과 이미지 경로가 매칭되도록 하여 저장한다.

아티스트 순서는 알파벳 순서가 될 것이므로 순서는 따로 저장하지 않는다.

관리자 유저 또는 프론트엔드 측에서 미리 파일명을 아티스트 이름으로 지정하여 넘겨주면 파일명의 순서에 따라 저장한다.

### Todo
이미지 파일명으로부터 아티스트 이름 추출하는 로직 구현

S3에 프로필 사진 저장 API 구현

전시 상세 조회 시 프로필 이미지 및 아티스트 이름 조회되도록 전시 상세 조회 API 수정

### Future
우선 전시 상세 조회 시 전시 영역과 전시 참여 아티스트 영역에 대한 정보 모두 반환하지만 추후에 일반 유저가 조회할 시 전시 참여 아티스트 영역에 대한 데이터를 따로 불러오도록 프론트엔드와 구현하면 필요하지 않은 데이터에 대한 조회가 백엔드 측에서 이루어지는 것을 방지하면 좋을 것이다.

closes #9 