### PR TITLE
전시 저장 기능에 텍스트 데이터 저장 기능 추가 (#11)

### DIFF
--- a/src/main/java/com/hid_web/be/InitDB.java
+++ b/src/main/java/com/hid_web/be/InitDB.java
@@ -32,7 +32,20 @@ public class InitDB {
         public void dbInit1() {
             ExhibitEntity exhibitEntity = new ExhibitEntity();
             List<ExhibitArtistEntity> exhibitArtistEntities = new ArrayList<>();
+
+            exhibitEntity.setMainThumbnailImageUrl("대표 이미지");
+
             ExhibitArtistEntity exhibitArtistEntityEntityKZ = new ExhibitArtistEntity();
+
+            exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntities);
+
+            exhibitEntity.setTitleKo("여름 전시 제목");
+            exhibitEntity.setTitleEn("Summer Exhibit Title");
+            exhibitEntity.setSubtitleKo("여름 전시 부제");
+            exhibitEntity.setSubtitleEn("Summer Exhibit Subtitle");
+            exhibitEntity.setTextKo("홍익대학교 산업디자인학과 2024 여름 전시 - 1");
+            exhibitEntity.setTextEn("HID Design 2024 Summer Exhibit - 1");
+            exhibitEntity.setVideoUrl("전시 영상 - 1");
 
             exhibitArtistEntityEntityKZ.setName("Designer A");
             exhibitArtistEntities.add(exhibitArtistEntityEntityKZ);
@@ -41,21 +54,24 @@ public class InitDB {
             exhibitArtistEntityEntityBM.setName("Designer B");
             exhibitArtistEntities.add(exhibitArtistEntityEntityBM);
 
-            exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntities);
-            exhibitEntity.setText("홍익대학교 산업디자인학과 2024 여름 전시 - 1");
-            exhibitEntity.setImageUrl("전시 이미지 - 1");
-            exhibitEntity.setVideoUrl("전시 영상 - 1");
-
-            exhibitEntity.setTitle("여름 전시 제목");
-            exhibitEntity.setSubtitle("여름 전시 부제");
-            exhibitEntity.setMainThumbnailImageUrl("대표 이미지");
-
             em.persist(exhibitEntity);
         }
 
         public void dbInit2() {
             ExhibitEntity exhibitEntity = new ExhibitEntity();
             List<ExhibitArtistEntity> exhibitArtistEntities = new ArrayList<>();
+
+            exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntities);
+
+            exhibitEntity.setTitleKo("여름 전시 제목");
+            exhibitEntity.setTitleEn("Summer Exhibit Title");
+            exhibitEntity.setSubtitleKo("여름 전시 부제");
+            exhibitEntity.setSubtitleEn("Summer Exhibit Subtitle");
+            exhibitEntity.setTextKo("홍익대학교 산업디자인학과 2024 여름 전시 - 2");
+            exhibitEntity.setTextEn("HID Design 2024 Summer Exhibit - 2");
+            exhibitEntity.setVideoUrl("전시 영상 - 2");
+
+            exhibitEntity.setMainThumbnailImageUrl("대표 이미지");
 
             ExhibitArtistEntity exhibitArtistEntityEntityJS = new ExhibitArtistEntity();
             exhibitArtistEntityEntityJS.setName("Designer C");
@@ -64,15 +80,6 @@ public class InitDB {
             ExhibitArtistEntity exhibitArtistEntityEntityYY = new ExhibitArtistEntity();
             exhibitArtistEntityEntityYY.setName("Designer D");
             exhibitArtistEntities.add(exhibitArtistEntityEntityYY);
-
-            exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntities);
-            exhibitEntity.setText("홍익대학교 산업디자인학과 2024 여름 전시 - 2");
-            exhibitEntity.setImageUrl("전시 이미지 - 2");
-            exhibitEntity.setVideoUrl("전시 영상 - 2");
-
-            exhibitEntity.setTitle("여름 전시 제목");
-            exhibitEntity.setSubtitle("여름 전시 부제");
-            exhibitEntity.setMainThumbnailImageUrl("대표 이미지");
 
             em.persist(exhibitEntity);
         }

--- a/src/main/java/com/hid_web/be/controller/ExhibitController.java
+++ b/src/main/java/com/hid_web/be/controller/ExhibitController.java
@@ -4,12 +4,12 @@ import com.hid_web.be.controller.response.ExhibitPreviewResponse;
 import com.hid_web.be.controller.response.ExhibitResponse;
 import com.hid_web.be.domain.exhibit.ExhibitEntity;
 import com.hid_web.be.service.ExhibitService;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,38 +17,31 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @RequestMapping("/exhibits")
 public class ExhibitController {
-
     private final ExhibitService exhibitService;
 
     @GetMapping("/previews")
-    public ResponseEntity<List<ExhibitPreviewResponse>> findAllExhibitPreview() {
+    public ResponseEntity<Result<List<ExhibitPreviewResponse>>> findAllExhibitPreview() {
         List<ExhibitEntity> exhibitEntityList = exhibitService.findAllExhibit();
         List<ExhibitPreviewResponse> exhibitPreviewResponseList = exhibitEntityList.stream()
                 .map(e -> ExhibitPreviewResponse.of(e))
                 .collect(Collectors.toList());
 
-        return ResponseEntity.ok().body(exhibitPreviewResponseList);
+        // Result 객체로 리스트를 감싸서 반환
+        return ResponseEntity.ok().body(new Result<>(exhibitPreviewResponseList));
     }
 
     @GetMapping("/{exhibitId}")
     public ResponseEntity<ExhibitResponse> findExhibitById(@PathVariable Long exhibitId) {
         ExhibitEntity exhibitEntity = exhibitService.findExhibitByExhibitId(exhibitId);
+
         return ResponseEntity.ok().body(ExhibitResponse.of(exhibitEntity));
     }
 
-    @PostMapping
-    public ResponseEntity<ExhibitResponse> createExhibit(
-            @RequestParam(value = "mainThumbnailImageFile") MultipartFile mainThumbnailImageFile,
-            @RequestParam(value = "additionalThumbnailImageFiles", required = false) List<MultipartFile> additionalThumbnailImageFiles,
-            @RequestParam(value = "detailImageFiles") List<MultipartFile> detailImageFiles,
-            @RequestParam(value = "profileImageFiles") List<MultipartFile> profileImageFiles) {
 
-        try {
-            ExhibitEntity exhibitEntity = exhibitService.createExhibit(mainThumbnailImageFile, additionalThumbnailImageFiles, detailImageFiles, profileImageFiles);
 
-            return ResponseEntity.ok(ExhibitResponse.of(exhibitEntity));
-        } catch (IOException e) {
-            return ResponseEntity.internalServerError().build();
-        }
+    @Data
+    @AllArgsConstructor
+    public class Result                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     <T> {
+        private T exhibitPreviews;
     }
 }

--- a/src/main/java/com/hid_web/be/controller/request/ExhibitDetailRequest.java
+++ b/src/main/java/com/hid_web/be/controller/request/ExhibitDetailRequest.java
@@ -1,0 +1,21 @@
+package com.hid_web.be.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExhibitDetailRequest {
+    private String titleKo;
+    private String titleEn;
+    private String subtitleKo;
+    private String subtitleEn;
+    private String textKo;
+    private String textEn;
+    private String videoUrl;
+}
+

--- a/src/main/java/com/hid_web/be/controller/response/ExhibitAdditionalThumbnailResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitAdditionalThumbnailResponse.java
@@ -1,0 +1,20 @@
+package com.hid_web.be.controller.response;
+
+import com.hid_web.be.domain.exhibit.ExhibitAdditionalThumbnailEntity;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExhibitAdditionalThumbnailResponse {
+    private String additionalThumbnailImageUrl;
+    private int position;
+
+    public static ExhibitAdditionalThumbnailResponse of(ExhibitAdditionalThumbnailEntity exhibitAdditionalThumbnailEntity) {
+        return ExhibitAdditionalThumbnailResponse.builder()
+                .additionalThumbnailImageUrl(exhibitAdditionalThumbnailEntity.getAdditionalThumbnailImageUrl())
+                .position(exhibitAdditionalThumbnailEntity.getPosition())
+                .build();
+    }
+}

--- a/src/main/java/com/hid_web/be/controller/response/ExhibitArtistResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitArtistResponse.java
@@ -11,10 +11,12 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExhibitArtistResponse {
     private String name;
+    private String profileImageUrl;
 
     public static ExhibitArtistResponse of(ExhibitArtistEntity exhibitArtistEntity) {
         return ExhibitArtistResponse.builder()
                 .name(exhibitArtistEntity.getName())
+                .profileImageUrl(exhibitArtistEntity.getProfileImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/hid_web/be/controller/response/ExhibitDetailImageResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitDetailImageResponse.java
@@ -1,0 +1,20 @@
+package com.hid_web.be.controller.response;
+
+import com.hid_web.be.domain.exhibit.ExhibitDetailImageEntity;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExhibitDetailImageResponse {
+    private String detailImageUrl;
+    private int position;
+
+    public static ExhibitDetailImageResponse of(ExhibitDetailImageEntity exhibitDetailImageEntity) {
+        return ExhibitDetailImageResponse.builder()
+                .detailImageUrl(exhibitDetailImageEntity.getDetailImageUrl())
+                .position(exhibitDetailImageEntity.getPosition())
+                .build();
+    }
+}

--- a/src/main/java/com/hid_web/be/controller/response/ExhibitPreviewResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitPreviewResponse.java
@@ -9,16 +9,21 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExhibitPreviewResponse {
     private Long exhibitId;
-    private String title;
-    private String subtitle;
-    private String thumbnailUrl;
+    private String mainThumbnailUrl;
+    private String titleKo;
+    private String titleEn;
+    private String subtitleKo;
+    private String subtitleEn;
 
     public static ExhibitPreviewResponse of(ExhibitEntity exhibitEntity) {
         return ExhibitPreviewResponse.builder()
                 .exhibitId(exhibitEntity.getExhibitId())
-                .title(exhibitEntity.getTitle())
-                .subtitle(exhibitEntity.getSubtitle())
-                .thumbnailUrl(exhibitEntity.getMainThumbnailImageUrl())
+                .mainThumbnailUrl(exhibitEntity.getMainThumbnailImageUrl())
+                .titleKo(exhibitEntity.getTitleKo())
+                .titleEn(exhibitEntity.getTitleEn())
+                .subtitleKo(exhibitEntity.getSubtitleKo())
+                .subtitleEn(exhibitEntity.getSubtitleEn())
                 .build();
     }
 }
+

--- a/src/main/java/com/hid_web/be/controller/response/ExhibitResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitResponse.java
@@ -10,25 +10,40 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExhibitResponse {
-
     private Long exhibitId;
-    private List<ExhibitArtistResponse> exhibitArtistList;
-    private String thumbnailUrl;
-    private String text;
-    private String imageUrl;
+    private String mainThumbnailImageUrl;
+    private List<ExhibitAdditionalThumbnailResponse> exhibitAdditionalThumbnailImageList;
+    private List<ExhibitDetailImageResponse> exhibitDetailImageEntityList;
+    private String titleKo;
+    private String titleEn;
+    private String subtitleKo;
+    private String subtitleEn;
+    private String textKo;
+    private String textEn;
     private String videoUrl;
+    private List<ExhibitArtistResponse> exhibitArtistList;
 
     // ExhibitEntity를 ExhibitResponse로 변환하는 정적 팩토리 메서드
     public static ExhibitResponse of(ExhibitEntity exhibitEntity) {
         return ExhibitResponse.builder()
                 .exhibitId(exhibitEntity.getExhibitId())
-                .exhibitArtistList(exhibitEntity.getExhibitArtistEntityList().stream()
-                        .map(ea -> ExhibitArtistResponse.of(ea))
+                .mainThumbnailImageUrl(exhibitEntity.getMainThumbnailImageUrl())
+                .exhibitAdditionalThumbnailImageList(exhibitEntity.getExhibitAdditionalThumbnailImageEntityList().stream()
+                        .map(ExhibitAdditionalThumbnailResponse::of)
                         .toList())
-                .thumbnailUrl(exhibitEntity.getMainThumbnailImageUrl())
-                .text(exhibitEntity.getText())
-                .imageUrl(exhibitEntity.getImageUrl())
+                .exhibitDetailImageEntityList(exhibitEntity.getExhibitDetailImageEntityList().stream()
+                        .map(ExhibitDetailImageResponse::of)
+                        .toList())
+                .titleKo(exhibitEntity.getTitleKo())
+                .titleEn(exhibitEntity.getTitleEn())
+                .subtitleKo(exhibitEntity.getSubtitleKo())
+                .subtitleEn(exhibitEntity.getSubtitleEn())
+                .textKo(exhibitEntity.getTextKo())
+                .textEn(exhibitEntity.getTextEn())
                 .videoUrl(exhibitEntity.getVideoUrl())
+                .exhibitArtistList(exhibitEntity.getExhibitArtistEntityList().stream()
+                        .map(ExhibitArtistResponse::of)
+                        .toList())
                 .build();
     }
 }

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitAdditionalThumbnailEntity.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitAdditionalThumbnailEntity.java
@@ -13,12 +13,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExhibitAdditionalThumbnailEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String additionalThumbnailImageUrl;
-
     private int position;
 }

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitArtistEntity.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitArtistEntity.java
@@ -13,12 +13,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExhibitArtistEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
-
     private String profileImageUrl;
 }

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitDetailImageEntity.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitDetailImageEntity.java
@@ -13,13 +13,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExhibitDetailImageEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String detailImageUrl;
-
     private int position;
 }
 

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitEntity.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitEntity.java
@@ -13,28 +13,42 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExhibitEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long exhibitId;
-
-    @OneToMany(cascade=CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name="exhibit_id")
-    private List<ExhibitArtistEntity> exhibitArtistEntityList = new ArrayList<>();
 
     private String mainThumbnailImageUrl;
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "exhibit_id")
-    private List<ExhibitAdditionalThumbnailEntity> additionalThumbnailImages = new ArrayList<>();
+    private List<ExhibitAdditionalThumbnailEntity> exhibitAdditionalThumbnailImageEntityList= new ArrayList<>();
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "exhibit_id")
-    private List<ExhibitDetailImageEntity> detailImages = new ArrayList<>();
+    private List<ExhibitDetailImageEntity> exhibitDetailImageEntityList = new ArrayList<>();
 
-    private String title;
-    private String subtitle;
-    private String text;
-    private String imageUrl;
+    @Column(length = 100)
+    private String titleKo;
+
+    @Column(length = 100)
+    private String titleEn;
+
+    @Column(length = 200)
+    private String subtitleKo;
+
+    @Column(length = 200)
+    private String subtitleEn;
+
+    @Column(length = 300)
+    private String textKo;
+
+    @Column(length = 700)
+    private String textEn;
+
     private String videoUrl;
+
+    @OneToMany(cascade=CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name="exhibit_id")
+    private List<ExhibitArtistEntity> exhibitArtistEntityList = new ArrayList<>();
 }
+

--- a/src/main/java/com/hid_web/be/service/ExhibitReader.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitReader.java
@@ -10,7 +10,6 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class ExhibitReader {
-
     private final ExhibitRepository exhibitRepository;
 
     public List<ExhibitEntity> findAllExhibit() {

--- a/src/main/java/com/hid_web/be/service/ExhibitService.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitService.java
@@ -13,7 +13,6 @@ import java.util.Map;
 @Slf4j
 @RequiredArgsConstructor
 public class ExhibitService {
-
     private final S3Writer s3Writer;
     private final ExhibitWriter exhibitWriter;
     private final ExhibitReader exhibitReader;
@@ -30,7 +29,7 @@ public class ExhibitService {
     public ExhibitEntity createExhibit(MultipartFile mainThumbnailImageFile,
                                        List<MultipartFile> additionalThumbnailImageFiles,
                                        List<MultipartFile> detailImageFiles,
-                                       List<MultipartFile> profileImageFiles) throws IOException {
+                                       List<MultipartFile> profileImageFiles, String titleKo, String titleEn, String subtitleKo, String subtitleEn, String textKo, String textEn, String videoUrl) throws IOException {
 
         String mainThumbnailImageUrl = s3Writer.writeFile(mainThumbnailImageFile, "main-thumbnail-image");
         List<String> additionalThumbnailImageUrls = s3Writer.writeFiles(additionalThumbnailImageFiles, "additional-thumbnails-images");
@@ -45,11 +44,13 @@ public class ExhibitService {
         ExhibitEntity exhibitEntity = exhibitWriter.createExhibit(
                 mainThumbnailImageUrl,
                 additionalThumbnailImageMap, detailImageMap,
-                "테스트 제목",
-                "테스트 부제",
-                "테스트 설명",
-                "테스트 이미지",
-                "테스트 영상",
+                titleKo,
+                titleEn,
+                subtitleKo,
+                subtitleEn,
+                textKo,
+                textEn,
+                videoUrl,
                 profileImageUrls, artistNames);
 
         return exhibitEntity;

--- a/src/main/java/com/hid_web/be/service/ExhibitWriter.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitWriter.java
@@ -15,16 +15,17 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class ExhibitWriter {
-
     private final ExhibitRepository exhibitRepository;
 
     public ExhibitEntity createExhibit(String mainThumbnailImageUrl,
                                        Map<Integer, String> additionalThumbnailImageMap,
                                        Map<Integer, String> detailImageMap,
-                                       String title,
-                                       String subtitle,
-                                       String text,
-                                       String imageUrl,
+                                       String titleKo,
+                                       String titleEn,
+                                       String subtitleKo,
+                                       String subtitleEn,
+                                       String textKo,
+                                       String textEn,
                                        String videoUrl,
                                        List<String> profileImageUrls,
                                        List<String> artistNames) {
@@ -50,14 +51,15 @@ public class ExhibitWriter {
             detailImages.add(detailImage);
         }
 
-        exhibitEntity.setMainThumbnailImageUrl(mainThumbnailImageUrl);
-        exhibitEntity.setAdditionalThumbnailImages(additionalThumbnails);
-        exhibitEntity.setDetailImages(detailImages);
+        exhibitEntity.setExhibitAdditionalThumbnailImageEntityList(additionalThumbnails);
+        exhibitEntity.setExhibitDetailImageEntityList(detailImages);
 
-        exhibitEntity.setTitle(title);
-        exhibitEntity.setSubtitle(subtitle);
-        exhibitEntity.setText(text);
-        exhibitEntity.setImageUrl(imageUrl);
+        exhibitEntity.setTitleKo(titleKo);
+        exhibitEntity.setTitleEn(titleEn);
+        exhibitEntity.setSubtitleKo(subtitleKo);
+        exhibitEntity.setSubtitleEn(subtitleEn);
+        exhibitEntity.setTextKo(textKo);
+        exhibitEntity.setTextEn(textEn);
         exhibitEntity.setVideoUrl(videoUrl);
 
         List<ExhibitArtistEntity> exhibitArtistEntities = new ArrayList<>();
@@ -74,8 +76,6 @@ public class ExhibitWriter {
             exhibitArtistEntities.add(artistEntity);
         }
         exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntities);
-
-
 
         return exhibitRepository.save(exhibitEntity);
     }

--- a/src/main/java/com/hid_web/be/service/S3Service.java
+++ b/src/main/java/com/hid_web/be/service/S3Service.java
@@ -14,7 +14,6 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class S3Service {
-
     private final S3Operations s3Operations;
 
     @Value("${spring.cloud.aws.s3.bucket}")

--- a/src/main/java/com/hid_web/be/service/S3Writer.java
+++ b/src/main/java/com/hid_web/be/service/S3Writer.java
@@ -14,7 +14,6 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class S3Writer {
-
     private final S3Operations s3Operations;
 
     @Value("${spring.cloud.aws.s3.bucket}")


### PR DESCRIPTION
### Description
S3 기반 이미지 파일 저장 기능 추가로부터 이미 구현한 API에 전시 상세 텍스트 데이터 추가

### Todo
전시 저장 API에 전시 정보 내 텍스트인 제목, 부제, 설명 저장 기능 추가

### Future
파일 수합 시 제한하기로 한 글자 수가 명확하게 지켜지지 않아 현재 글자 수 제한을 넉넉하게 제한했지만 웹부 측과 협의가 필요할 것 같다.

closes #11 