### PR TITLE
전시 영역 내 저장 시 전시마다 UUID 부여하여 구분 및 아티스트 영역 내 텍스트 데이터 저장 기능 추가 (#13)

### DIFF
--- a/src/main/java/com/hid_web/be/InitDB.java
+++ b/src/main/java/com/hid_web/be/InitDB.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class InitDB {
     private final InitService initService;
 
-    @PostConstruct
+//    @PostConstruct
     public void init() {
         initService.dbInit1();
         initService.dbInit2();
@@ -47,11 +47,11 @@ public class InitDB {
             exhibitEntity.setTextEn("HID Design 2024 Summer Exhibit - 1");
             exhibitEntity.setVideoUrl("전시 영상 - 1");
 
-            exhibitArtistEntityEntityKZ.setName("Designer A");
+            exhibitArtistEntityEntityKZ.setArtistNameEn("Designer A");
             exhibitArtistEntities.add(exhibitArtistEntityEntityKZ);
 
             ExhibitArtistEntity exhibitArtistEntityEntityBM = new ExhibitArtistEntity();
-            exhibitArtistEntityEntityBM.setName("Designer B");
+            exhibitArtistEntityEntityBM.setArtistNameEn("Designer B");
             exhibitArtistEntities.add(exhibitArtistEntityEntityBM);
 
             em.persist(exhibitEntity);
@@ -74,11 +74,11 @@ public class InitDB {
             exhibitEntity.setMainThumbnailImageUrl("대표 이미지");
 
             ExhibitArtistEntity exhibitArtistEntityEntityJS = new ExhibitArtistEntity();
-            exhibitArtistEntityEntityJS.setName("Designer C");
+            exhibitArtistEntityEntityJS.setArtistNameEn("Designer C");
             exhibitArtistEntities.add(exhibitArtistEntityEntityJS);
 
             ExhibitArtistEntity exhibitArtistEntityEntityYY = new ExhibitArtistEntity();
-            exhibitArtistEntityEntityYY.setName("Designer D");
+            exhibitArtistEntityEntityYY.setArtistNameEn("Designer D");
             exhibitArtistEntities.add(exhibitArtistEntityEntityYY);
 
             em.persist(exhibitEntity);

--- a/src/main/java/com/hid_web/be/controller/ExhibitController.java
+++ b/src/main/java/com/hid_web/be/controller/ExhibitController.java
@@ -1,5 +1,6 @@
 package com.hid_web.be.controller;
 
+import com.hid_web.be.controller.request.CreateExhibitRequest;
 import com.hid_web.be.controller.response.ExhibitPreviewResponse;
 import com.hid_web.be.controller.response.ExhibitResponse;
 import com.hid_web.be.domain.exhibit.ExhibitEntity;
@@ -9,6 +10,7 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,14 +33,33 @@ public class ExhibitController {
 
     @GetMapping("/{exhibitId}")
     public ResponseEntity<ExhibitResponse> findExhibitById(@PathVariable Long exhibitId) {
+
         ExhibitEntity exhibitEntity = exhibitService.findExhibitByExhibitId(exhibitId);
 
         return ResponseEntity.ok().body(ExhibitResponse.of(exhibitEntity));
     }
 
+
+    @PostMapping
+    public ResponseEntity<ExhibitResponse> createExhibit(@ModelAttribute CreateExhibitRequest createExhibitRequest) {
+        try {
+            ExhibitEntity exhibitEntity = exhibitService.createExhibit(
+                    createExhibitRequest.getMainThumbnailImageFile(),
+                    createExhibitRequest.getAdditionalThumbnailImageFiles(),
+                    createExhibitRequest.getDetailImageFiles(),
+                    createExhibitRequest.toExhibitDetail(),
+                    createExhibitRequest.toExhibitArtistList()
+            );
+
+            return ResponseEntity.ok(ExhibitResponse.of(exhibitEntity));
+        } catch (IOException e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
     @Data
     @AllArgsConstructor
-    public class Result                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     <T> {
+    public class Result<T> {
         private T data;
     }
 }

--- a/src/main/java/com/hid_web/be/controller/request/CreateExhibitArtistRequest.java
+++ b/src/main/java/com/hid_web/be/controller/request/CreateExhibitArtistRequest.java
@@ -1,0 +1,23 @@
+package com.hid_web.be.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateExhibitArtistRequest {
+    private String artistNameKo;
+    private String artistNameEn;
+    private String role;
+    private String email;
+    private String instagramUrl;
+    private String behanceUrl;
+    private String linkedinUrl;
+    private MultipartFile profileImageFile;
+}
+

--- a/src/main/java/com/hid_web/be/controller/request/CreateExhibitDetailRequest.java
+++ b/src/main/java/com/hid_web/be/controller/request/CreateExhibitDetailRequest.java
@@ -1,0 +1,20 @@
+package com.hid_web.be.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateExhibitDetailRequest {
+    private String titleKo;
+    private String titleEn;
+    private String subtitleKo;
+    private String subtitleEn;
+    private String textKo;
+    private String textEn;
+    private String videoUrl;
+}

--- a/src/main/java/com/hid_web/be/controller/request/CreateExhibitRequest.java
+++ b/src/main/java/com/hid_web/be/controller/request/CreateExhibitRequest.java
@@ -1,0 +1,51 @@
+package com.hid_web.be.controller.request;
+
+import com.hid_web.be.domain.exhibit.ExhibitArtist;
+import com.hid_web.be.domain.exhibit.ExhibitDetail;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateExhibitRequest {
+    private MultipartFile mainThumbnailImageFile;
+    private List<MultipartFile> additionalThumbnailImageFiles;
+    private List<MultipartFile> detailImageFiles;
+    private CreateExhibitDetailRequest createExhibitDetailRequest;
+    private List<CreateExhibitArtistRequest> createExhibitArtistRequestList;
+
+    public ExhibitDetail toExhibitDetail() {
+        return new ExhibitDetail(
+                createExhibitDetailRequest.getTitleKo(),
+                createExhibitDetailRequest.getTitleEn(),
+                createExhibitDetailRequest.getSubtitleKo(),
+                createExhibitDetailRequest.getSubtitleEn(),
+                createExhibitDetailRequest.getTextKo(),
+                createExhibitDetailRequest.getTextEn(),
+                createExhibitDetailRequest.getVideoUrl()
+        );
+    }
+
+    public List<ExhibitArtist> toExhibitArtistList() {
+        return createExhibitArtistRequestList.stream()
+                .map(createExhibitArtistRequest -> new ExhibitArtist(
+                        createExhibitArtistRequest.getProfileImageFile(),
+                        null,
+                        createExhibitArtistRequest.getArtistNameKo(),
+                        createExhibitArtistRequest.getArtistNameEn(),
+                        createExhibitArtistRequest.getRole(),
+                        createExhibitArtistRequest.getEmail(),
+                        createExhibitArtistRequest.getInstagramUrl(),
+                        createExhibitArtistRequest.getBehanceUrl(),
+                        createExhibitArtistRequest.getLinkedinUrl()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/hid_web/be/controller/response/ExhibitArtistResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitArtistResponse.java
@@ -3,20 +3,32 @@ package com.hid_web.be.controller.response;
 import com.hid_web.be.domain.exhibit.ExhibitArtistEntity;
 import lombok.*;
 
-import java.util.List;
-
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExhibitArtistResponse {
-    private String name;
+    private Long id;
     private String profileImageUrl;
+    private String artistNameKo;
+    private String artistNameEn;
+    private String role;
+    private String email;
+    private String instagramUrl;
+    private String behanceUrl;
+    private String linkedinUrl;
 
     public static ExhibitArtistResponse of(ExhibitArtistEntity exhibitArtistEntity) {
         return ExhibitArtistResponse.builder()
-                .name(exhibitArtistEntity.getName())
+                .id(exhibitArtistEntity.getId())
                 .profileImageUrl(exhibitArtistEntity.getProfileImageUrl())
+                .artistNameKo(exhibitArtistEntity.getArtistNameKo())
+                .artistNameEn(exhibitArtistEntity.getArtistNameEn())
+                .role(exhibitArtistEntity.getRole())
+                .email(exhibitArtistEntity.getEmail())
+                .instagramUrl(exhibitArtistEntity.getInstagramUrl())
+                .behanceUrl(exhibitArtistEntity.getBehanceUrl())
+                .linkedinUrl(exhibitArtistEntity.getLinkedinUrl())
                 .build();
     }
 }

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitArtist.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitArtist.java
@@ -1,22 +1,18 @@
 package com.hid_web.be.domain.exhibit;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
-@Entity
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ExhibitArtistEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-    private String profileImageUrl;
+public class ExhibitArtist {
+    private MultipartFile profileImageFile;
+    private String profileImageFileUrl;
     private String artistNameKo;
     private String artistNameEn;
     private String role;

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitDetail.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitDetail.java
@@ -1,0 +1,20 @@
+package com.hid_web.be.domain.exhibit;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExhibitDetail {
+    private String titleKo;
+    private String titleEn;
+    private String subtitleKo;
+    private String subtitleEn;
+    private String textKo;
+    private String textEn;
+    private String videoUrl;
+}

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitEntity.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitEntity.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,6 +15,8 @@ public class ExhibitEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long exhibitId;
+
+    private String exhibitUUID;
 
     private String mainThumbnailImageUrl;
 

--- a/src/main/java/com/hid_web/be/repository/ExhibitRepository.java
+++ b/src/main/java/com/hid_web/be/repository/ExhibitRepository.java
@@ -2,7 +2,6 @@ package com.hid_web.be.repository;
 
 import com.hid_web.be.domain.exhibit.ExhibitEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 
 public interface ExhibitRepository extends JpaRepository<ExhibitEntity, Long> {

--- a/src/main/java/com/hid_web/be/service/ExhibitReader.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitReader.java
@@ -4,7 +4,6 @@ import com.hid_web.be.domain.exhibit.ExhibitEntity;
 import com.hid_web.be.repository.ExhibitRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
 import java.util.List;
 
 @Service

--- a/src/main/java/com/hid_web/be/service/ExhibitWriter.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitWriter.java
@@ -1,13 +1,9 @@
 package com.hid_web.be.service;
 
-import com.hid_web.be.domain.exhibit.ExhibitAdditionalThumbnailEntity;
-import com.hid_web.be.domain.exhibit.ExhibitArtistEntity;
-import com.hid_web.be.domain.exhibit.ExhibitDetailImageEntity;
-import com.hid_web.be.domain.exhibit.ExhibitEntity;
+import com.hid_web.be.domain.exhibit.*;
 import com.hid_web.be.repository.ExhibitRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -17,22 +13,15 @@ import java.util.Map;
 public class ExhibitWriter {
     private final ExhibitRepository exhibitRepository;
 
-    public ExhibitEntity createExhibit(String mainThumbnailImageUrl,
+    public ExhibitEntity createExhibit(String exhibitUUID,
+                                       String mainThumbnailImageUrl,
                                        Map<Integer, String> additionalThumbnailImageMap,
                                        Map<Integer, String> detailImageMap,
-                                       String titleKo,
-                                       String titleEn,
-                                       String subtitleKo,
-                                       String subtitleEn,
-                                       String textKo,
-                                       String textEn,
-                                       String videoUrl,
-                                       List<String> profileImageUrls,
-                                       List<String> artistNames) {
+                                       ExhibitDetail exhibitDetail,
+                                       List<ExhibitArtist> exhibitArtistList) {
 
         ExhibitEntity exhibitEntity = new ExhibitEntity();
-
-
+        exhibitEntity.setExhibitUUID(exhibitUUID);
         exhibitEntity.setMainThumbnailImageUrl(mainThumbnailImageUrl);
 
         List<ExhibitAdditionalThumbnailEntity> additionalThumbnails = new ArrayList<>();
@@ -54,31 +43,33 @@ public class ExhibitWriter {
         exhibitEntity.setExhibitAdditionalThumbnailImageEntityList(additionalThumbnails);
         exhibitEntity.setExhibitDetailImageEntityList(detailImages);
 
-        exhibitEntity.setTitleKo(titleKo);
-        exhibitEntity.setTitleEn(titleEn);
-        exhibitEntity.setSubtitleKo(subtitleKo);
-        exhibitEntity.setSubtitleEn(subtitleEn);
-        exhibitEntity.setTextKo(textKo);
-        exhibitEntity.setTextEn(textEn);
-        exhibitEntity.setVideoUrl(videoUrl);
+        exhibitEntity.setTitleKo(exhibitDetail.getTitleKo());
+        exhibitEntity.setTitleEn(exhibitDetail.getTitleEn());
+        exhibitEntity.setSubtitleKo(exhibitDetail.getSubtitleKo());
+        exhibitEntity.setSubtitleEn(exhibitDetail.getSubtitleEn());
+        exhibitEntity.setTextKo(exhibitDetail.getTextKo());
+        exhibitEntity.setTextEn(exhibitDetail.getTextEn());
+        exhibitEntity.setVideoUrl(exhibitDetail.getVideoUrl());
 
-        List<ExhibitArtistEntity> exhibitArtistEntities = new ArrayList<>();
-
-        for (int i = 0; i < artistNames.size(); i++) {
+        List<ExhibitArtistEntity> exhibitArtistEntityList = new ArrayList<>();
+        for (ExhibitArtist artist : exhibitArtistList) {
             ExhibitArtistEntity artistEntity = new ExhibitArtistEntity();
+            artistEntity.setArtistNameKo(artist.getArtistNameKo());
+            artistEntity.setArtistNameEn(artist.getArtistNameEn());
+            artistEntity.setRole(artist.getRole());
+            artistEntity.setEmail(artist.getEmail());
+            artistEntity.setInstagramUrl(artist.getInstagramUrl());
+            artistEntity.setBehanceUrl(artist.getBehanceUrl());
+            artistEntity.setLinkedinUrl(artist.getLinkedinUrl());
+            artistEntity.setProfileImageUrl(artist.getProfileImageFileUrl());
 
-            artistEntity.setName(artistNames.get(i));
-
-            if (i < profileImageUrls.size()) {
-                artistEntity.setProfileImageUrl(profileImageUrls.get(i));
-            }
-
-            exhibitArtistEntities.add(artistEntity);
+            exhibitArtistEntityList.add(artistEntity);
         }
-        exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntities);
+        exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntityList);
 
         return exhibitRepository.save(exhibitEntity);
     }
 }
+
 
 

--- a/src/main/java/com/hid_web/be/service/S3Writer.java
+++ b/src/main/java/com/hid_web/be/service/S3Writer.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -46,6 +45,4 @@ public class S3Writer {
     public String generateFileUrl(String objectKey) {
         return "https://" + bucketName + ".s3.amazonaws.com/" + objectKey;
     }
-
 }
-


### PR DESCRIPTION
### Description
현재 전시마다 같은 계층 구조 및 파일명으로 저장하므로 구분이 필요므로 소모임명과 팀명으로 할 수 있겠지만 우선 테스트를 위해 UUID로 구분하려고 한다.

아티스트 영역 내 텍스트 데이터 저장 기능을 추가한다.

### Todo
전시 영역 내 저장 시 전시마다 UUID 부여
아티스트 영역 내 텍스트 데이터 저장 기능 추가

### Future
UUID로 구현 시 이미지 서버에서 원하는 전시를 찾아보기 힘들 수 있으므로 소모임명과 팀명을 그대로 사용하는 방안을 찾으면 좋을 것이다.

closes #13