### PR TITLE
S3 기반 전시 영역 내 부가 이미지, 상세 이미지 파일 저장 기능 로직 변경 (#21)

### DIFF
--- a/src/main/java/com/hid_web/be/controller/ExhibitController.java
+++ b/src/main/java/com/hid_web/be/controller/ExhibitController.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -47,8 +46,8 @@ public class ExhibitController {
         try {
             ExhibitEntity exhibitEntity = exhibitService.createExhibit(
                     createExhibitRequest.getMainThumbnailImageFile(),
-                    createExhibitRequest.getAdditionalThumbnailImageFiles(),
-                    createExhibitRequest.getDetailImageFiles(),
+                    createExhibitRequest.toAdditionalThumbnailImages(),
+                    createExhibitRequest.toDetailImages(),
                     createExhibitRequest.toExhibitDetail(),
                     createExhibitRequest.toExhibitArtistList()
             );

--- a/src/main/java/com/hid_web/be/controller/request/CreateExhibitAdditionalThumbnailImageRequest.java
+++ b/src/main/java/com/hid_web/be/controller/request/CreateExhibitAdditionalThumbnailImageRequest.java
@@ -1,0 +1,12 @@
+package com.hid_web.be.controller.request;
+
+import org.springframework.web.multipart.MultipartFile;
+import lombok.*;
+
+@Getter
+@Setter
+public class CreateExhibitAdditionalThumbnailImageRequest {
+    private MultipartFile file;
+    private String url;
+    private int position;
+}

--- a/src/main/java/com/hid_web/be/controller/request/CreateExhibitDetailImageRequest.java
+++ b/src/main/java/com/hid_web/be/controller/request/CreateExhibitDetailImageRequest.java
@@ -1,0 +1,12 @@
+package com.hid_web.be.controller.request;
+
+import org.springframework.web.multipart.MultipartFile;
+import lombok.*;
+
+@Getter
+@Setter
+public class CreateExhibitDetailImageRequest {
+    private MultipartFile file;
+    private String url;
+    private int position;
+}

--- a/src/main/java/com/hid_web/be/controller/request/CreateExhibitRequest.java
+++ b/src/main/java/com/hid_web/be/controller/request/CreateExhibitRequest.java
@@ -1,27 +1,50 @@
 package com.hid_web.be.controller.request;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.web.multipart.MultipartFile;
+import lombok.*;
+import com.hid_web.be.domain.exhibit.ExhibitAdditionalThumbnailImage;
 import com.hid_web.be.domain.exhibit.ExhibitArtist;
 import com.hid_web.be.domain.exhibit.ExhibitDetail;
-import com.hid_web.be.domain.exhibit.ExhibitImageType;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.springframework.web.multipart.MultipartFile;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
+import com.hid_web.be.domain.exhibit.ExhibitDetailImage;
 
 @Getter
 @Setter
-@NoArgsConstructor
-@AllArgsConstructor
 public class CreateExhibitRequest {
     private MultipartFile mainThumbnailImageFile;
-    private List<MultipartFile> additionalThumbnailImageFiles;
-    private List<MultipartFile> detailImageFiles;
+    private List<CreateExhibitAdditionalThumbnailImageRequest> createAdditionalThumbnailImageRequests;
+    private List<CreateExhibitDetailImageRequest> createDetailImageRequests;
     private CreateExhibitDetailRequest createExhibitDetailRequest;
     private List<CreateExhibitArtistRequest> createExhibitArtistRequestList;
+
+    public List<ExhibitAdditionalThumbnailImage> toAdditionalThumbnailImages() {
+        if (createAdditionalThumbnailImageRequests == null) {
+            return null;
+        }
+
+        return createAdditionalThumbnailImageRequests.stream()
+                .map(request -> new ExhibitAdditionalThumbnailImage(
+                        request.getFile(),
+                        request.getUrl(),
+                        request.getPosition()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    public List<ExhibitDetailImage> toDetailImages() {
+        if (createDetailImageRequests == null) {
+            return null;
+        }
+
+        return createDetailImageRequests.stream()
+                .map(request -> new ExhibitDetailImage(
+                        request.getFile(),
+                        request.getUrl(),
+                        request.getPosition()
+                ))
+                .collect(Collectors.toList());
+    }
 
     public ExhibitDetail toExhibitDetail() {
         return new ExhibitDetail(

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitAdditionalThumbnailImage.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitAdditionalThumbnailImage.java
@@ -12,4 +12,10 @@ public class ExhibitAdditionalThumbnailImage {
     private String url;
     private int position;
     private ExhibitImageType type;
+
+    public ExhibitAdditionalThumbnailImage(MultipartFile file, String url, int position) {
+        this.file = file;
+        this.url = url;
+        this.position = position;
+    }
 }

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitDetailImage.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitDetailImage.java
@@ -15,5 +15,11 @@ public class ExhibitDetailImage {
     private String url;
     private int position;
     private ExhibitImageType type;
+
+    public ExhibitDetailImage(MultipartFile file, String url, int position) {
+        this.file = file;
+        this.url = url;
+        this.position = position;
+    }
 }
 

--- a/src/main/java/com/hid_web/be/service/ExhibitExtractor.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitExtractor.java
@@ -5,59 +5,12 @@ import com.hid_web.be.domain.exhibit.ExhibitArtistEntity;
 import com.hid_web.be.domain.exhibit.ExhibitDetailImageEntity;
 import com.hid_web.be.domain.exhibit.ExhibitEntity;
 import org.springframework.stereotype.Service;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
 public class ExhibitExtractor {
-
-    public List<String> extractArtistNamesFromUrls(List<String> profileImageUrls) {
-        List<String> artistNames = new ArrayList<>();
-
-        for (String url : profileImageUrls) {
-            String fileName = url.substring(url.lastIndexOf('/') + 1);
-            String fileNameWithoutExtension = fileName.substring(0, fileName.lastIndexOf('.'));
-            String artistName = fileNameWithoutExtension.replace("_", " ");
-            artistNames.add(artistName);
-        }
-
-        return artistNames;
-    }
-
-    public Map<Integer, String> extractUrlMapWithPosition(List<String> imageUrls) {
-        Map<Integer, String> urlMap = new HashMap<>();
-
-        for (String url : imageUrls) {
-            int position = extractPositionFromFilename(url);
-            urlMap.put(position, url);
-        }
-
-        return urlMap;
-    }
-
-    public Map<Integer, String> extractUrlMapWithPositionV2(List<String> imageUrls, List<Integer> positions) {
-        Map<Integer, String> urlMap = new HashMap<>();
-
-        for (int i = 0; i < imageUrls.size(); i++) {
-            int position = positions.get(i);
-            String url = imageUrls.get(i);
-            urlMap.put(position, url);
-        }
-
-        return urlMap;
-    }
-
-
-    public int extractPositionFromFilename(String fileName) {
-        String positionStr = fileName.substring(fileName.lastIndexOf("_") + 1, fileName.lastIndexOf('.'));
-        int position = Integer.parseInt(positionStr);
-
-        return position;
-    }
-
     public Map<String, ExhibitAdditionalThumbnailEntity> extractAdditionalImageMapByUrl(ExhibitEntity exhibitEntity) {
         Map<String, ExhibitAdditionalThumbnailEntity> entityMap = exhibitEntity.getExhibitAdditionalThumbnailImageEntityList()
                 .stream()

--- a/src/main/java/com/hid_web/be/service/ExhibitWriter.java
+++ b/src/main/java/com/hid_web/be/service/ExhibitWriter.java
@@ -1,14 +1,14 @@
 package com.hid_web.be.service;
 
-import com.hid_web.be.domain.exhibit.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import com.hid_web.be.repository.ExhibitRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import com.hid_web.be.domain.exhibit.*;
 
+// Implement Layer의 Exhibit에 대해 DB Create, Update, Delete를 담당하는 구현체
 @Service
 @RequiredArgsConstructor
 public class ExhibitWriter {
@@ -16,34 +16,38 @@ public class ExhibitWriter {
 
     public ExhibitEntity createExhibit(String exhibitUUID,
                                        String mainThumbnailImageUrl,
-                                       Map<Integer, String> additionalThumbnailImageMap,
-                                       Map<Integer, String> detailImageMap,
+                                       List<ExhibitAdditionalThumbnailImage> additionalThumbnailImages,
+                                       List<ExhibitDetailImage> detailImages,
                                        ExhibitDetail exhibitDetail,
                                        List<ExhibitArtist> exhibitArtistList) {
-
+        // 전시 엔티티 생성
         ExhibitEntity exhibitEntity = new ExhibitEntity();
+        // 전시 고유 UUID 저장
         exhibitEntity.setExhibitUUID(exhibitUUID);
+        // 메인 이미지 Urls 엔티티에 저장
         exhibitEntity.setMainThumbnailImageUrl(mainThumbnailImageUrl);
 
-        List<ExhibitAdditionalThumbnailEntity> additionalThumbnails = new ArrayList<>();
-        for (Map.Entry<Integer, String> entry : additionalThumbnailImageMap.entrySet()) {
-            ExhibitAdditionalThumbnailEntity additionalThumbnail = new ExhibitAdditionalThumbnailEntity();
-            additionalThumbnail.setPosition(entry.getKey());
-            additionalThumbnail.setAdditionalThumbnailImageUrl(entry.getValue());
-            additionalThumbnails.add(additionalThumbnail);
+        // 부가 이미지 Urls 엔티티에 저장
+        List<ExhibitAdditionalThumbnailEntity> additionalImageEntities = new ArrayList<>();
+        for (ExhibitAdditionalThumbnailImage additionalThumbnailImage : additionalThumbnailImages) {
+            ExhibitAdditionalThumbnailEntity additionalImageEntity = new ExhibitAdditionalThumbnailEntity();
+            additionalImageEntity.setPosition(additionalThumbnailImage.getPosition());
+            additionalImageEntity.setAdditionalThumbnailImageUrl(additionalThumbnailImage.getUrl());
+            additionalImageEntities.add(additionalImageEntity);
         }
+        exhibitEntity.setExhibitAdditionalThumbnailImageEntityList(additionalImageEntities);
 
-        List<ExhibitDetailImageEntity> detailImages = new ArrayList<>();
-        for (Map.Entry<Integer, String> entry : detailImageMap.entrySet()) {
-            ExhibitDetailImageEntity detailImage = new ExhibitDetailImageEntity();
-            detailImage.setPosition(entry.getKey());
-            detailImage.setDetailImageUrl(entry.getValue());
-            detailImages.add(detailImage);
+        // 상세 이미지 Urls 엔티티에 저장
+        List<ExhibitDetailImageEntity> detailImageEntities = new ArrayList<>();
+        for (ExhibitDetailImage detailImage : detailImages) {
+            ExhibitDetailImageEntity detailImageEntity = new ExhibitDetailImageEntity();
+            detailImageEntity.setPosition(detailImage.getPosition());
+            detailImageEntity.setDetailImageUrl(detailImage.getUrl());
+            detailImageEntities.add(detailImageEntity);
         }
+        exhibitEntity.setExhibitDetailImageEntityList(detailImageEntities);
 
-        exhibitEntity.setExhibitAdditionalThumbnailImageEntityList(additionalThumbnails);
-        exhibitEntity.setExhibitDetailImageEntityList(detailImages);
-
+        // 상세 Texts 엔티티에 저장
         exhibitEntity.setTitleKo(exhibitDetail.getTitleKo());
         exhibitEntity.setTitleEn(exhibitDetail.getTitleEn());
         exhibitEntity.setSubtitleKo(exhibitDetail.getSubtitleKo());
@@ -52,6 +56,7 @@ public class ExhibitWriter {
         exhibitEntity.setTextEn(exhibitDetail.getTextEn());
         exhibitEntity.setVideoUrl(exhibitDetail.getVideoUrl());
 
+        // 전시 Artists 엔티티에 저장
         List<ExhibitArtistEntity> exhibitArtistEntityList = new ArrayList<>();
         for (ExhibitArtist artist : exhibitArtistList) {
             ExhibitArtistEntity artistEntity = new ExhibitArtistEntity();
@@ -69,6 +74,7 @@ public class ExhibitWriter {
         }
         exhibitEntity.setExhibitArtistEntityList(exhibitArtistEntityList);
 
+        // Spring Data JPA를 이용하여 DB에 저장
         return exhibitRepository.save(exhibitEntity);
     }
 

--- a/src/main/java/com/hid_web/be/service/S3Writer.java
+++ b/src/main/java/com/hid_web/be/service/S3Writer.java
@@ -20,22 +20,8 @@ public class S3Writer {
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
 
-    public String writeFile(MultipartFile file, String folderPath) throws IOException {
-        return uploadSingleFile(file, folderPath);
-    }
-
     public String writeFileV2(MultipartFile file, String folderPath) throws IOException {
         return uploadSingleFileV2(file, folderPath);
-    }
-
-    public List<String> writeFiles(List<MultipartFile> files, String folderPath) throws IOException {
-        List<String> urls = new ArrayList<>();
-        if (files != null && !files.isEmpty()) {
-            for (MultipartFile file : files) {
-                urls.add(uploadSingleFile(file, folderPath));
-            }
-        }
-        return urls;
     }
 
     public List<String> writeFilesV2(List<MultipartFile> files, String folderPath) throws IOException {
@@ -46,17 +32,6 @@ public class S3Writer {
             }
         }
         return urls;
-    }
-
-
-    public String uploadSingleFile(MultipartFile file, String folderPath) throws IOException {
-        String objectKey = folderPath + "/" + file.getOriginalFilename();
-
-        try (InputStream inputStream = file.getInputStream()) {
-            s3Operations.upload(bucketName, objectKey, inputStream);
-        }
-
-        return generateFileUrl(objectKey);
     }
 
     public String uploadSingleFileV2(MultipartFile file, String folderPath) throws IOException {
@@ -73,7 +48,7 @@ public class S3Writer {
         return "https://" + bucketName + ".s3.amazonaws.com/" + objectKey;
     }
 
-    public void deleteFolder(String folderPath) {
+    public void deleteObjects(String folderPath) {
         List<S3Resource> objects = s3Operations.listObjects(bucketName, folderPath);
 
         for (S3Resource object : objects) {


### PR DESCRIPTION
### Description
이전엔 부가 이미지, 상세 이미지 파일이 복수이고 순서가 존재하므로 파일명에 순서를 포함하는 방식으로 구현했었다.
Update 로직과 동일하게 프론트엔드가 따로 Postion을 전달하도록 변경하여 통일성을 향상하고자 한다.

### Todo
파일명으로부터 Postion을 추출하는 메소드 삭제
전시 저장 시 부가 이미지, 상세 이미지에 대해 이미지마다 Postion을 지정하여 저장하도록 전시 저장 API 수정

### Future
이미지에 지정된 순서를 프론트엔드부터 백엔드까지 유지하는 방식에 대해 고민해보면 좋을 것이다.

close #21