### PR TITLE
전시 영역 내 상세 텍스트 데이터에 동적 쿼리를 위한 필드 추가 (#25)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.2.1")
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3' // S3 연동
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store' // Parameter Store 연동
+	implementation 'org.springframework.boot:spring-boot-starter-validation' // 유효성 검사
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/hid_web/be/controller/request/CreateExhibitDetailRequest.java
+++ b/src/main/java/com/hid_web/be/controller/request/CreateExhibitDetailRequest.java
@@ -1,5 +1,7 @@
 package com.hid_web.be.controller.request;
 
+import com.hid_web.be.domain.exhibit.ExhibitType;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +12,20 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateExhibitDetailRequest {
+    // 전시 타입
+    @NotNull(message = "전시 타입은 필수입니다.")
+    private ExhibitType exhibitType;
+
+    // 전시 연도
+    @NotNull(message = "전시 연도는 필수입니다.")
+    private Integer year;
+
+    // 졸업 전시 전공 이름
+    private String major; // 졸업 전시 필터링
+
+    // 소모임 전시 이름
+    private String club;  // 소모임 전시 필터링
+
     private String titleKo;
     private String titleEn;
     private String subTitleKo;

--- a/src/main/java/com/hid_web/be/controller/request/CreateExhibitRequest.java
+++ b/src/main/java/com/hid_web/be/controller/request/CreateExhibitRequest.java
@@ -47,6 +47,10 @@ public class CreateExhibitRequest {
 
     public ExhibitDetail toDetails() {
         return new ExhibitDetail(
+                details.getExhibitType(),
+                details.getYear(),
+                details.getMajor(),
+                details.getClub(),
                 details.getTitleKo(),
                 details.getTitleEn(),
                 details.getSubTitleKo(),

--- a/src/main/java/com/hid_web/be/controller/request/UpdateExhibitDetailRequest.java
+++ b/src/main/java/com/hid_web/be/controller/request/UpdateExhibitDetailRequest.java
@@ -1,5 +1,7 @@
 package com.hid_web.be.controller.request;
 
+import com.hid_web.be.domain.exhibit.ExhibitType;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
@@ -7,6 +9,14 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateExhibitDetailRequest {
+    @NotNull(message = "전시 타입은 필수입니다.")
+    private ExhibitType exhibitType;
+
+    @NotNull(message = "전시 연도는 필수입니다.")
+    private Integer year;
+
+    private String major;
+    private String club;
     private String titleKo;
     private String titleEn;
     private String subTitleKo;

--- a/src/main/java/com/hid_web/be/controller/request/UpdateExhibitRequest.java
+++ b/src/main/java/com/hid_web/be/controller/request/UpdateExhibitRequest.java
@@ -56,6 +56,10 @@ public class UpdateExhibitRequest {
         }
 
         return new ExhibitDetail(
+                details.getExhibitType(),
+                details.getYear(),
+                details.getMajor(),
+                details.getClub(),
                 details.getTitleKo(),
                 details.getTitleEn(),
                 details.getSubTitleKo(),

--- a/src/main/java/com/hid_web/be/controller/response/ExhibitResponse.java
+++ b/src/main/java/com/hid_web/be/controller/response/ExhibitResponse.java
@@ -1,5 +1,6 @@
 package com.hid_web.be.controller.response;
 
+import com.hid_web.be.domain.exhibit.ExhibitType;
 import com.hid_web.be.storage.ExhibitEntity;
 import lombok.*;
 
@@ -11,6 +12,10 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExhibitResponse {
     private Long exhibitId;
+    private ExhibitType exhibitType;
+    private Integer year;
+    private String major;
+    private String club;
     private String mainImgUrl;
     private List<ExhibitSubImgResponse> subImgs;
     private List<ExhibitDetailImgResponse> detailImgs;
@@ -27,6 +32,10 @@ public class ExhibitResponse {
     public static ExhibitResponse of(ExhibitEntity exhibitEntity) {
         return ExhibitResponse.builder()
                 .exhibitId(exhibitEntity.getExhibitId())
+                .exhibitType(exhibitEntity.getExhibitType())
+                .year(exhibitEntity.getYear())
+                .major(exhibitEntity.getMajor())
+                .club(exhibitEntity.getClub())
                 .mainImgUrl(exhibitEntity.getMainImgUrl())
                 .subImgs(exhibitEntity.getSubImgEntities().stream()
                         .map(ExhibitSubImgResponse::of)

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitDetail.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitDetail.java
@@ -7,6 +7,10 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExhibitDetail {
+    private ExhibitType exhibitType;
+    private Integer year;
+    private String major;
+    private String club;
     private String titleKo;
     private String titleEn;
     private String subTitleKo;

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitService.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitService.java
@@ -221,6 +221,18 @@ public class ExhibitService {
 
         // 전시 상세 텍스트 Update
         if (details != null) {
+            if (details.getExhibitType() != null) {
+                exhibitEntity.setExhibitType(details.getExhibitType());
+            }
+            if (details.getYear() != null) {
+                exhibitEntity.setYear(details.getYear());
+            }
+            if (details.getMajor() != null) {
+                exhibitEntity.setMajor(details.getMajor());
+            }
+            if (details.getClub() != null) {
+                exhibitEntity.setClub(details.getClub());
+            }
             if (details.getTitleKo() != null) {
                 exhibitEntity.setTitleKo(details.getTitleKo());
             }

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitType.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitType.java
@@ -1,0 +1,7 @@
+package com.hid_web.be.domain.exhibit;
+
+public enum ExhibitType {
+    GRADUATION(),
+    CLUB();
+}
+

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitWriter.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitWriter.java
@@ -48,6 +48,10 @@ public class ExhibitWriter {
         exhibitEntity.setDetailImgEntities(detailImageEntities);
 
         // 상세 Texts 엔티티에 저장
+        exhibitEntity.setExhibitType(details.getExhibitType());
+        exhibitEntity.setYear(details.getYear());
+        exhibitEntity.setMajor(details.getMajor());
+        exhibitEntity.setClub(details.getClub());
         exhibitEntity.setTitleKo(details.getTitleKo());
         exhibitEntity.setTitleEn(details.getTitleEn());
         exhibitEntity.setSubTitleKo(details.getSubTitleKo());

--- a/src/main/java/com/hid_web/be/storage/ExhibitEntity.java
+++ b/src/main/java/com/hid_web/be/storage/ExhibitEntity.java
@@ -1,6 +1,8 @@
 package com.hid_web.be.storage;
 
+import com.hid_web.be.domain.exhibit.ExhibitType;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
@@ -18,6 +20,17 @@ public class ExhibitEntity {
 
     @Column(name = "exhibit_uuid")
     private String exhibitUUID;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ExhibitType exhibitType;
+
+    @Column(nullable = false)
+    private int year;
+
+    private String major;
+
+    private String club;
 
     private String mainImgUrl;
 


### PR DESCRIPTION
### Description
전시 필터링 기능을 구현할 것이다.

졸업 전시 또는 소모임 전시로 1차 필터링을 하고, 졸업 전시에선 전공 이름으로, 소모임 전시에선 소모임 이름으로 2차 필터링을 하려고 한다.

전공도 수가 많고, 소모임도 수가 많고, 보통 최신 순, 추천 순 등 다른 필터링 조건이 추가될 것을 고려하여 일반적인 정적 쿼리로 구현하기엔 경우의 수가 많고 복잡함이 너무 클 것이라고 판단했다.

동적 쿼리로 해결하는 것으로 결정하고, 조건 필드를 전체적으로 추가하려고 한다.

### Todo
전시 엔티티에 전시 타입, 전시 연도, 전공 이름, 소모임 이름에 해당하는 필드 추가

### Future
동적 쿼리로 구현하면서 성능 상의 문제가 없는지 확인해야 할 것 갇타.

close #25