### PR TITLE
공지사항 조회 기능 추가 (#29)

### DIFF
--- a/src/main/java/com/hid_web/be/InitNoticeDB.java
+++ b/src/main/java/com/hid_web/be/InitNoticeDB.java
@@ -1,0 +1,47 @@
+package com.hid_web.be;
+
+import com.hid_web.be.storage.community.NoticeEntity;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class InitNoticeDB {
+
+    private final InitService initService;
+
+    @PostConstruct
+    public void init() {
+        initService.dbInit();
+    }
+
+    @Component
+    @Transactional
+    @RequiredArgsConstructor
+    static class InitService {
+
+        private final EntityManager em;
+
+        public void dbInit() {
+
+            NoticeEntity notice1 = new NoticeEntity();
+            notice1.setTitle("공지사항 1");
+            notice1.setAuthor("TA");
+            notice1.setCreatedDate(LocalDateTime.of(2024, 3, 2, 0, 0));
+            notice1.setHasAttachment(true);
+            em.persist(notice1);
+            
+            NoticeEntity notice2 = new NoticeEntity();
+            notice2.setTitle("공지사항 2");
+            notice2.setAuthor("Council");
+            notice2.setCreatedDate(LocalDateTime.of(2024, 3, 1, 0, 0));
+            notice2.setHasAttachment(false);
+            em.persist(notice2);
+        }
+    }
+}

--- a/src/main/java/com/hid_web/be/controller/community/NoticeController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NoticeController.java
@@ -1,0 +1,26 @@
+package com.hid_web.be.controller.community;
+
+import com.hid_web.be.controller.community.response.NoticeResponse;
+import com.hid_web.be.domain.community.NoticeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@RestController
+@RequestMapping("/notice")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    public NoticeController(NoticeService noticeService) {
+        this.noticeService = noticeService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<NoticeResponse>> getAllNotices() {
+        List<NoticeResponse> notices = noticeService.getAllNotices();
+        return ResponseEntity.ok(notices);
+    }
+}

--- a/src/main/java/com/hid_web/be/controller/community/response/NoticeResponse.java
+++ b/src/main/java/com/hid_web/be/controller/community/response/NoticeResponse.java
@@ -1,0 +1,24 @@
+package com.hid_web.be.controller.community.response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class NoticeResponse {
+    private Long id;
+    private String title;
+    private String author;
+    private LocalDateTime createdDate;
+    private Boolean hasAttachment;
+
+    public NoticeResponse(Long id, String title, String author, LocalDateTime createdDate, Boolean hasAttachment) {
+        this.id = id;
+        this.title = title;
+        this.author = author;
+        this.createdDate = createdDate;
+        this.hasAttachment = hasAttachment;
+    }
+
+}

--- a/src/main/java/com/hid_web/be/domain/community/NoticeService.java
+++ b/src/main/java/com/hid_web/be/domain/community/NoticeService.java
@@ -1,0 +1,34 @@
+package com.hid_web.be.domain.community;
+
+import com.hid_web.be.controller.community.response.NoticeResponse;
+import com.hid_web.be.storage.community.NoticeEntity;
+import com.hid_web.be.storage.community.NoticeRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    public NoticeService(NoticeRepository noticeRepository) {
+        this.noticeRepository = noticeRepository;
+    }
+
+    public List<NoticeResponse> getAllNotices() {
+
+        List<NoticeEntity> noticeEntities = noticeRepository.findAll();
+
+        return noticeEntities.stream()
+                .map(notice -> new NoticeResponse(
+                        notice.getId(),
+                        notice.getTitle(),
+                        notice.getAuthor(),
+                        notice.getCreatedDate(),
+                        notice.getHasAttachment()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/hid_web/be/storage/community/NoticeEntity.java
+++ b/src/main/java/com/hid_web/be/storage/community/NoticeEntity.java
@@ -1,0 +1,31 @@
+package com.hid_web.be.storage.community;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+//@Table(name = "notice")
+public class NoticeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(nullable = false)
+    private String author;
+
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    @Column(name = "has_attachment")
+    private Boolean hasAttachment;
+}

--- a/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
+++ b/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
@@ -1,0 +1,9 @@
+package com.hid_web.be.storage.community;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<NoticeEntity, Long> {
+
+}


### PR DESCRIPTION
# Description
공지사항 기능 중 조회 기능을 개발하여 사용자에게 공지사항 목록을 제공한다. 이 기능은 공지사항의 제목, 작성자, 작성일, 첨부파일 여부 등을 반환하도록 설계한다. 또한, 페이징과 카테고리 필터링이 적용될 수 있도록 확장 가능성을 고려하여 설계한다.

# Todo
각 레이어별 커뮤니티 패키지 추가
공지사항 조회 API 설계 및 개발
Controller, Service, Repository 클래스 작성
공지사항 목록을 반환하는 엔드포인트 구현
반환 데이터: 제목, 공지 일자, 작성자, 첨부파일 여부

# Future
공지사항 세부 조회 기능 추가
특정 공지사항 클릭 시 상세 정보를 반환하는 API 개발

closes #29 