### PR TITLE
공지사항 상세 조회 기능 추가 (#31)

### DIFF
--- a/src/main/java/com/hid_web/be/InitNoticeDB.java
+++ b/src/main/java/com/hid_web/be/InitNoticeDB.java
@@ -30,17 +30,21 @@ public class InitNoticeDB {
         public void dbInit() {
 
             NoticeEntity notice1 = new NoticeEntity();
-            notice1.setTitle("공지사항 1");
+            notice1.setTitle("[세종테크노파크] 세종RISE 센터 사업 대학생 대상 교육 수요조사.");
             notice1.setAuthor("TA");
             notice1.setCreatedDate(LocalDateTime.of(2024, 3, 2, 0, 0));
-            notice1.setHasAttachment(true);
+            notice1.setAttachmentUrl("https://example.com/file1.pdf");
+            notice1.setImageUrl("https://example.com/image1.jpg");
+            notice1.setContent("세종 지역 대학생을 대상으로 한 교육 수요조사입니다. 상세 내용은 첨부파일을 참고해주세요.");
             em.persist(notice1);
-            
+
             NoticeEntity notice2 = new NoticeEntity();
-            notice2.setTitle("공지사항 2");
+            notice2.setTitle("(중요) 기자재 대여 안내");
             notice2.setAuthor("Council");
             notice2.setCreatedDate(LocalDateTime.of(2024, 3, 1, 0, 0));
-            notice2.setHasAttachment(false);
+            notice2.setAttachmentUrl(null);
+            notice2.setImageUrl("https://example.com/image2.jpg");
+            notice2.setContent("기자재 대여에 관한 새로운 규정을 확인해주세요. 이미지와 상세 내용을 참고 바랍니다.");
             em.persist(notice2);
         }
     }

--- a/src/main/java/com/hid_web/be/controller/community/NoticeController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NoticeController.java
@@ -1,15 +1,18 @@
 package com.hid_web.be.controller.community;
 
+import com.hid_web.be.controller.community.response.NoticeDetailResponse;
 import com.hid_web.be.controller.community.response.NoticeResponse;
 import com.hid_web.be.domain.community.NoticeService;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/notice")
+@RequestMapping("/notices")
 public class NoticeController {
 
     private final NoticeService noticeService;
@@ -23,4 +26,11 @@ public class NoticeController {
         List<NoticeResponse> notices = noticeService.getAllNotices();
         return ResponseEntity.ok(notices);
     }
+
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<NoticeDetailResponse> getNoticeDetail(@PathVariable Long noticeId) {
+        NoticeDetailResponse response = noticeService.getNoticeDetail(noticeId);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/hid_web/be/controller/community/response/NoticeDetailResponse.java
+++ b/src/main/java/com/hid_web/be/controller/community/response/NoticeDetailResponse.java
@@ -1,0 +1,33 @@
+package com.hid_web.be.controller.community.response;
+
+import com.hid_web.be.storage.community.NoticeEntity;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeDetailResponse {
+    private Long id;
+    private String title;
+    private String author;
+    private LocalDateTime createdDate;
+    private int views;
+    private String attachmentUrl;
+    private String imageUrl;
+    private String content;
+
+    public NoticeDetailResponse(NoticeEntity entity) {
+        this.id = entity.getId();
+        this.title = entity.getTitle();
+        this.author = entity.getAuthor();
+        this.createdDate = entity.getCreatedDate();
+        this.views = entity.getViews();
+        this.attachmentUrl = entity.getAttachmentUrl();
+        this.imageUrl = entity.getImageUrl();
+        this.content = entity.getContent();
+    }
+
+}

--- a/src/main/java/com/hid_web/be/controller/community/response/NoticeResponse.java
+++ b/src/main/java/com/hid_web/be/controller/community/response/NoticeResponse.java
@@ -6,19 +6,20 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NoticeResponse {
     private Long id;
     private String title;
     private String author;
     private LocalDateTime createdDate;
-    private Boolean hasAttachment;
+    private String attachmentUrl;
 
-    public NoticeResponse(Long id, String title, String author, LocalDateTime createdDate, Boolean hasAttachment) {
+    public NoticeResponse(Long id, String title, String author, LocalDateTime createdDate, String attachmentUrl) {
         this.id = id;
         this.title = title;
         this.author = author;
         this.createdDate = createdDate;
-        this.hasAttachment = hasAttachment;
+        this.attachmentUrl = attachmentUrl;
     }
 
 }

--- a/src/main/java/com/hid_web/be/domain/community/NoticeService.java
+++ b/src/main/java/com/hid_web/be/domain/community/NoticeService.java
@@ -1,8 +1,10 @@
 package com.hid_web.be.domain.community;
 
+import com.hid_web.be.controller.community.response.NoticeDetailResponse;
 import com.hid_web.be.controller.community.response.NoticeResponse;
 import com.hid_web.be.storage.community.NoticeEntity;
 import com.hid_web.be.storage.community.NoticeRepository;
+import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -27,8 +29,19 @@ public class NoticeService {
                         notice.getTitle(),
                         notice.getAuthor(),
                         notice.getCreatedDate(),
-                        notice.getHasAttachment()
+                        notice.getAttachmentUrl()
                 ))
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public NoticeDetailResponse getNoticeDetail(Long id) {
+        NoticeEntity notice = noticeRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Notice not found"));
+
+        // 조회수 증가
+        notice.setViews(notice.getViews() + 1);
+
+        return new NoticeDetailResponse(notice);
     }
 }

--- a/src/main/java/com/hid_web/be/storage/community/NoticeEntity.java
+++ b/src/main/java/com/hid_web/be/storage/community/NoticeEntity.java
@@ -26,6 +26,16 @@ public class NoticeEntity {
     @Column(name = "created_date")
     private LocalDateTime createdDate;
 
-    @Column(name = "has_attachment")
-    private Boolean hasAttachment;
+    @Column(nullable = false)
+    private int views;
+
+    @Column(name = "attachment_url", length = 500)
+    private String attachmentUrl;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
 }


### PR DESCRIPTION
# Description
공지사항 목록에서 제목을 클릭했을 때 상세 페이지를 보여줄 수 있도록 공지사항 상세 조회 기능을 개발한다.

# Todo
공지사항 상세 페이지에는 제목, 작성일자, 조회수, 작성자, 첨부파일, 이미지, 텍스트를 포함해야 한다.
공지사항 테이블에 조회수, 이미지, 텍스트 필드 추가
공지사항 상세 응답 DTO 추가 및 조회 API 구현
첨부파일을 url 형태로 저장하기 위한 필드 수정

# Future
이미지 및 첨부파일 기능 연동
뉴스이벤트 조회 기능

closes #31 