### PR TITLE
공지사항 중요 필드 추가 및 정렬 기능과 페이징 구현 (#33)

### DIFF
--- a/src/main/java/com/hid_web/be/InitNoticeDB.java
+++ b/src/main/java/com/hid_web/be/InitNoticeDB.java
@@ -28,24 +28,16 @@ public class InitNoticeDB {
         private final EntityManager em;
 
         public void dbInit() {
-
-            NoticeEntity notice1 = new NoticeEntity();
-            notice1.setTitle("[세종테크노파크] 세종RISE 센터 사업 대학생 대상 교육 수요조사.");
-            notice1.setAuthor("TA");
-            notice1.setCreatedDate(LocalDateTime.of(2024, 3, 2, 0, 0));
-            notice1.setAttachmentUrl("https://example.com/file1.pdf");
-            notice1.setImageUrl("https://example.com/image1.jpg");
-            notice1.setContent("세종 지역 대학생을 대상으로 한 교육 수요조사입니다. 상세 내용은 첨부파일을 참고해주세요.");
-            em.persist(notice1);
-
-            NoticeEntity notice2 = new NoticeEntity();
-            notice2.setTitle("(중요) 기자재 대여 안내");
-            notice2.setAuthor("Council");
-            notice2.setCreatedDate(LocalDateTime.of(2024, 3, 1, 0, 0));
-            notice2.setAttachmentUrl(null);
-            notice2.setImageUrl("https://example.com/image2.jpg");
-            notice2.setContent("기자재 대여에 관한 새로운 규정을 확인해주세요. 이미지와 상세 내용을 참고 바랍니다.");
-            em.persist(notice2);
+            for (int i = 1; i <= 20; i++) {
+                NoticeEntity notice = new NoticeEntity();
+                notice.setTitle(i % 5 == 0 ? "중요 공지사항 " + i : "일반 공지사항 " + i);
+                notice.setAuthor(i % 3 == 0 ? "TA" : "Council");
+                notice.setCreatedDate(LocalDateTime.now().minusDays(20-i));
+                notice.setViews(0);
+                notice.setAttachmentUrl(i % 4 == 0 ? "https://example.com/file" + i + ".pdf" : null);
+                notice.setImportant(i % 5 == 0);
+                em.persist(notice);
+            }
         }
     }
 }

--- a/src/main/java/com/hid_web/be/controller/community/NoticeController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NoticeController.java
@@ -3,13 +3,15 @@ package com.hid_web.be.controller.community;
 import com.hid_web.be.controller.community.response.NoticeDetailResponse;
 import com.hid_web.be.controller.community.response.NoticeResponse;
 import com.hid_web.be.domain.community.NoticeService;
-import org.springframework.http.MediaType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import java.util.List;
 
 @RestController
 @RequestMapping("/notices")
@@ -22,9 +24,8 @@ public class NoticeController {
     }
 
     @GetMapping
-    public ResponseEntity<List<NoticeResponse>> getAllNotices() {
-        List<NoticeResponse> notices = noticeService.getAllNotices();
-        return ResponseEntity.ok(notices);
+    public Page<NoticeResponse> getAllNotices(@PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        return noticeService.getAllNotices(pageable);
     }
 
     @GetMapping("/{noticeId}")

--- a/src/main/java/com/hid_web/be/controller/community/response/NoticeDetailResponse.java
+++ b/src/main/java/com/hid_web/be/controller/community/response/NoticeDetailResponse.java
@@ -18,6 +18,7 @@ public class NoticeDetailResponse {
     private String attachmentUrl;
     private String imageUrl;
     private String content;
+    private boolean isImportant;
 
     public NoticeDetailResponse(NoticeEntity entity) {
         this.id = entity.getId();
@@ -28,6 +29,7 @@ public class NoticeDetailResponse {
         this.attachmentUrl = entity.getAttachmentUrl();
         this.imageUrl = entity.getImageUrl();
         this.content = entity.getContent();
+        this.isImportant = entity.isImportant();
     }
 
 }

--- a/src/main/java/com/hid_web/be/controller/community/response/NoticeResponse.java
+++ b/src/main/java/com/hid_web/be/controller/community/response/NoticeResponse.java
@@ -1,11 +1,13 @@
 package com.hid_web.be.controller.community.response;
 
+import com.hid_web.be.storage.community.NoticeEntity;
 import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NoticeResponse {
     private Long id;
@@ -13,13 +15,15 @@ public class NoticeResponse {
     private String author;
     private LocalDateTime createdDate;
     private String attachmentUrl;
+    private boolean isImportant;
 
-    public NoticeResponse(Long id, String title, String author, LocalDateTime createdDate, String attachmentUrl) {
-        this.id = id;
-        this.title = title;
-        this.author = author;
-        this.createdDate = createdDate;
-        this.attachmentUrl = attachmentUrl;
+    public NoticeResponse(NoticeEntity entity) {
+        this.id = entity.getId();
+        this.title = entity.getTitle();
+        this.author = entity.getAuthor();
+        this.createdDate = entity.getCreatedDate();
+        this.attachmentUrl = entity.getAttachmentUrl();
+        this.isImportant = entity.isImportant();
     }
 
 }

--- a/src/main/java/com/hid_web/be/domain/community/NoticeService.java
+++ b/src/main/java/com/hid_web/be/domain/community/NoticeService.java
@@ -5,10 +5,9 @@ import com.hid_web.be.controller.community.response.NoticeResponse;
 import com.hid_web.be.storage.community.NoticeEntity;
 import com.hid_web.be.storage.community.NoticeRepository;
 import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class NoticeService {
@@ -19,19 +18,10 @@ public class NoticeService {
         this.noticeRepository = noticeRepository;
     }
 
-    public List<NoticeResponse> getAllNotices() {
+    public Page<NoticeResponse> getAllNotices(Pageable pageable) {
+        Page<NoticeEntity> noticeEntities = noticeRepository.findAllByOrderByIsImportantDescCreatedDateDesc(pageable);
 
-        List<NoticeEntity> noticeEntities = noticeRepository.findAll();
-
-        return noticeEntities.stream()
-                .map(notice -> new NoticeResponse(
-                        notice.getId(),
-                        notice.getTitle(),
-                        notice.getAuthor(),
-                        notice.getCreatedDate(),
-                        notice.getAttachmentUrl()
-                ))
-                .collect(Collectors.toList());
+        return noticeEntities.map(NoticeResponse::new);
     }
 
     @Transactional

--- a/src/main/java/com/hid_web/be/storage/community/NoticeEntity.java
+++ b/src/main/java/com/hid_web/be/storage/community/NoticeEntity.java
@@ -38,4 +38,7 @@ public class NoticeEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    @Column(name = "is_important", nullable = false)
+    private boolean isImportant;
+
 }

--- a/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
+++ b/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
@@ -1,9 +1,14 @@
 package com.hid_web.be.storage.community;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NoticeRepository extends JpaRepository<NoticeEntity, Long> {
+    @Query("SELECT n FROM NoticeEntity n ORDER BY n.isImportant DESC, n.createdDate DESC")
+    Page<NoticeEntity> findAllByOrderByIsImportantDescCreatedDateDesc(Pageable pageable);
 
 }


### PR DESCRIPTION
# Description
공지사항에 "중요" 표시 여부를 나타내는 필드를 추가한다.
이를 기반으로 공지사항 목록에서 중요 공지사항을 상단에 표시하는 정렬 기능을 구현한다.
또한, 공지사항 데이터가 많아질 경우를 대비하여 페이징 기능을 추가하여 성능을 최적화합니다.

# Todo
is_Important 필드 추가에 따른 DB매핑
중요 표시 여부와 작성일자를 기준으로 정렬된 공지사항 목록 반환
기본 페이징 로직 구현

# Future
이미지 및 첨부파일 기능 연동
뉴스이벤트 조회 기능
동적 페이징 기능으로 변경

closes #33