### PR TITLE
뉴스 & 이벤트 조회 기능 추가 (#35)

### DIFF
--- a/src/main/java/com/hid_web/be/InitNewsEventDB.java
+++ b/src/main/java/com/hid_web/be/InitNewsEventDB.java
@@ -1,0 +1,45 @@
+package com.hid_web.be;
+
+import com.hid_web.be.domain.community.NewsEventCategory;
+import com.hid_web.be.storage.community.NewsEventEntity;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class InitNewsEventDB {
+
+    private final InitService initService;
+
+    @PostConstruct
+    public void init() {
+        initService.dbInit();
+    }
+
+    @Component
+    @Transactional
+    @RequiredArgsConstructor
+    static class InitService {
+
+        private final EntityManager em;
+
+        public void dbInit() {
+            for (int i = 1; i <= 20; i++) {
+                NewsEventEntity newsEvent = new NewsEventEntity();
+                newsEvent.setThumbnailUrl("https://example.com/image" + i + ".jpg");
+                newsEvent.setCreatedDate(LocalDateTime.now().minusDays(i));
+                newsEvent.setTitle("뉴스이벤트 제목 " + i);
+                newsEvent.setCategory(i % 4 == 0 ? NewsEventCategory.RECRUIT :
+                        i % 4 == 1 ? NewsEventCategory.CONTEST :
+                                i % 4 == 2 ? NewsEventCategory.LECTURE_SEMINAR :
+                                        NewsEventCategory.AWARD);
+                em.persist(newsEvent);
+            }
+        }
+    }
+}

--- a/src/main/java/com/hid_web/be/controller/community/NewsEventController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NewsEventController.java
@@ -1,0 +1,22 @@
+package com.hid_web.be.controller.community;
+
+import com.hid_web.be.controller.community.response.NewsEventResponse;
+import com.hid_web.be.domain.community.NewsEventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@RestController
+@RequestMapping("/newsEvent")
+@RequiredArgsConstructor
+public class NewsEventController {
+    private final NewsEventService newsEventService;
+
+    @GetMapping
+    public List<NewsEventResponse> getAllNewsEvents() {
+        return newsEventService.getAllNewsEvents();
+    }
+
+}

--- a/src/main/java/com/hid_web/be/controller/community/response/NewsEventResponse.java
+++ b/src/main/java/com/hid_web/be/controller/community/response/NewsEventResponse.java
@@ -1,0 +1,27 @@
+package com.hid_web.be.controller.community.response;
+
+import com.hid_web.be.storage.community.NewsEventEntity;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsEventResponse {
+    private Long id;
+    private String thumbnailUrl;
+    private LocalDateTime createdDate;
+    private String title;
+    private String category;
+
+    public NewsEventResponse(NewsEventEntity entity) {
+        this.id = entity.getId();
+        this.thumbnailUrl = entity.getThumbnailUrl();
+        this.createdDate = entity.getCreatedDate();
+        this.title = entity.getTitle();
+        this.category = entity.getCategory().name();
+    }
+
+}

--- a/src/main/java/com/hid_web/be/domain/community/NewsEventCategory.java
+++ b/src/main/java/com/hid_web/be/domain/community/NewsEventCategory.java
@@ -1,0 +1,5 @@
+package com.hid_web.be.domain.community;
+
+public enum NewsEventCategory {
+    RECRUIT, CONTEST, LECTURE_SEMINAR, AWARD
+}

--- a/src/main/java/com/hid_web/be/domain/community/NewsEventService.java
+++ b/src/main/java/com/hid_web/be/domain/community/NewsEventService.java
@@ -1,0 +1,25 @@
+package com.hid_web.be.domain.community;
+
+import com.hid_web.be.controller.community.response.NewsEventResponse;
+import com.hid_web.be.storage.community.NewsEventEntity;
+import com.hid_web.be.storage.community.NewsEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NewsEventService {
+    private final NewsEventRepository newsEventRepository;
+
+    public List<NewsEventResponse> getAllNewsEvents() {
+        List<NewsEventEntity> newsEventEntities = newsEventRepository.findAll();
+
+        return newsEventEntities.stream()
+                .map(NewsEventResponse::new)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/hid_web/be/storage/community/NewsEventEntity.java
+++ b/src/main/java/com/hid_web/be/storage/community/NewsEventEntity.java
@@ -1,0 +1,33 @@
+package com.hid_web.be.storage.community;
+
+import com.hid_web.be.domain.community.NewsEventCategory;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewsEventEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "thumbnail_url", nullable = false, length = 500)
+    private String thumbnailUrl;
+
+    @Column(name = "created_date", nullable = false)
+    private LocalDateTime createdDate;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private NewsEventCategory category;
+
+}

--- a/src/main/java/com/hid_web/be/storage/community/NewsEventRepository.java
+++ b/src/main/java/com/hid_web/be/storage/community/NewsEventRepository.java
@@ -1,0 +1,9 @@
+package com.hid_web.be.storage.community;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NewsEventRepository extends JpaRepository<NewsEventEntity, Long> {
+
+}


### PR DESCRIPTION
# Description
뉴스 & 이벤트에서 조회 기능을 통해 사용자에게 뉴스 & 이벤트 목록을 제공한다. 이 기능은 뉴스 & 이벤트는 썸네일 이미지, 작성일자, 제목, 카테고리를 반환하도록 설계한다.
또한, 페이징과 카테고리 필터링이 적용될 수 있도록 확장 가능성을 고려하여 설계한다.

# Todo
뉴스이벤트 조회 API 설계 및 개발
Controller, Service, Repository 클래스 작성
뉴스이벤트 목록을 반환하는 엔드포인트 구현
반환 데이터: 썸네일 이미지, 작성일자, 제목, 카테고리

# Future
뉴스이벤트 세부 조회 기능 추가
페이징 및 카테고리 필터링 기능 추가

closes #35 