### PR TITLE
뉴스 & 이벤트 상세 조회 기능 및 페이징 구현 (#37)

### DIFF
--- a/src/main/java/com/hid_web/be/InitNewsEventDB.java
+++ b/src/main/java/com/hid_web/be/InitNewsEventDB.java
@@ -29,7 +29,7 @@ public class InitNewsEventDB {
         private final EntityManager em;
 
         public void dbInit() {
-            for (int i = 1; i <= 20; i++) {
+            for (int i = 1; i <= 10; i++) {
                 NewsEventEntity newsEvent = new NewsEventEntity();
                 newsEvent.setThumbnailUrl("https://example.com/image" + i + ".jpg");
                 newsEvent.setCreatedDate(LocalDateTime.now().minusDays(i));
@@ -38,6 +38,9 @@ public class InitNewsEventDB {
                         i % 4 == 1 ? NewsEventCategory.CONTEST :
                                 i % 4 == 2 ? NewsEventCategory.LECTURE_SEMINAR :
                                         NewsEventCategory.AWARD);
+                newsEvent.setContent("뉴스 & 이벤트 본문 내용 " + i);
+                newsEvent.setAttachmentUrl(i % 2 == 0 ? "https://example.com/file" + i + ".pdf" : null);
+                newsEvent.setViews(0);
                 em.persist(newsEvent);
             }
         }

--- a/src/main/java/com/hid_web/be/controller/community/NewsEventController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NewsEventController.java
@@ -4,11 +4,14 @@ import com.hid_web.be.controller.community.response.NewsEventDetailResponse;
 import com.hid_web.be.controller.community.response.NewsEventResponse;
 import com.hid_web.be.domain.community.NewsEventService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import java.util.List;
 
 @RestController
 @RequestMapping("/newsEvent")
@@ -17,8 +20,9 @@ public class NewsEventController {
     private final NewsEventService newsEventService;
 
     @GetMapping
-    public List<NewsEventResponse> getAllNewsEvents() {
-        return newsEventService.getAllNewsEvents();
+    public Page<NewsEventResponse> getAllNewsEvents(
+            @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        return newsEventService.getAllNewsEvents(pageable);
     }
 
     @GetMapping("/{newsEventId}")

--- a/src/main/java/com/hid_web/be/controller/community/NewsEventController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NewsEventController.java
@@ -1,9 +1,11 @@
 package com.hid_web.be.controller.community;
 
+import com.hid_web.be.controller.community.response.NewsEventDetailResponse;
 import com.hid_web.be.controller.community.response.NewsEventResponse;
 import com.hid_web.be.domain.community.NewsEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
@@ -19,4 +21,8 @@ public class NewsEventController {
         return newsEventService.getAllNewsEvents();
     }
 
+    @GetMapping("/{newsEventId}")
+    public NewsEventDetailResponse getNewsEventDetail(@PathVariable Long newsEventId) {
+        return newsEventService.getNewsEventDetail(newsEventId);
+    }
 }

--- a/src/main/java/com/hid_web/be/controller/community/response/NewsEventDetailResponse.java
+++ b/src/main/java/com/hid_web/be/controller/community/response/NewsEventDetailResponse.java
@@ -1,0 +1,33 @@
+package com.hid_web.be.controller.community.response;
+
+import com.hid_web.be.storage.community.NewsEventEntity;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsEventDetailResponse {
+    private Long id;
+    private String title;
+    private LocalDateTime createdDate;
+    private int views;
+    private String thumbnailUrl;
+    private String content;
+    private String attachmentUrl;
+    private String category;
+
+    public NewsEventDetailResponse(NewsEventEntity entity) {
+        this.id = entity.getId();
+        this.title = entity.getTitle();
+        this.createdDate = entity.getCreatedDate();
+        this.views = entity.getViews();
+        this.thumbnailUrl = entity.getThumbnailUrl();
+        this.content = entity.getContent();
+        this.attachmentUrl = entity.getAttachmentUrl();
+        this.category = entity.getCategory().name();
+    }
+
+}

--- a/src/main/java/com/hid_web/be/domain/community/NewsEventService.java
+++ b/src/main/java/com/hid_web/be/domain/community/NewsEventService.java
@@ -5,22 +5,18 @@ import com.hid_web.be.controller.community.response.NewsEventResponse;
 import com.hid_web.be.storage.community.NewsEventEntity;
 import com.hid_web.be.storage.community.NewsEventRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class NewsEventService {
     private final NewsEventRepository newsEventRepository;
 
-    public List<NewsEventResponse> getAllNewsEvents() {
-        List<NewsEventEntity> newsEventEntities = newsEventRepository.findAll();
-
-        return newsEventEntities.stream()
-                .map(NewsEventResponse::new)
-                .collect(Collectors.toList());
+    public Page<NewsEventResponse> getAllNewsEvents(Pageable pageable) {
+        return newsEventRepository.findAll(pageable)
+                .map(NewsEventResponse::new);
     }
 
     public NewsEventDetailResponse getNewsEventDetail(Long newsEventId) {

--- a/src/main/java/com/hid_web/be/domain/community/NewsEventService.java
+++ b/src/main/java/com/hid_web/be/domain/community/NewsEventService.java
@@ -1,5 +1,6 @@
 package com.hid_web.be.domain.community;
 
+import com.hid_web.be.controller.community.response.NewsEventDetailResponse;
 import com.hid_web.be.controller.community.response.NewsEventResponse;
 import com.hid_web.be.storage.community.NewsEventEntity;
 import com.hid_web.be.storage.community.NewsEventRepository;
@@ -20,6 +21,15 @@ public class NewsEventService {
         return newsEventEntities.stream()
                 .map(NewsEventResponse::new)
                 .collect(Collectors.toList());
+    }
+
+    public NewsEventDetailResponse getNewsEventDetail(Long newsEventId) {
+        NewsEventEntity newsEvent = newsEventRepository.findById(newsEventId)
+                .orElseThrow(() -> new RuntimeException("뉴스 & 이벤트가 존재하지 않습니다. ID: " + newsEventId));
+
+        newsEvent.setViews(newsEvent.getViews() + 1);
+
+        return new NewsEventDetailResponse(newsEvent);
     }
 
 }

--- a/src/main/java/com/hid_web/be/domain/community/NoticeService.java
+++ b/src/main/java/com/hid_web/be/domain/community/NoticeService.java
@@ -25,8 +25,8 @@ public class NoticeService {
     }
 
     @Transactional
-    public NoticeDetailResponse getNoticeDetail(Long id) {
-        NoticeEntity notice = noticeRepository.findById(id)
+    public NoticeDetailResponse getNoticeDetail(Long noticeId) {
+        NoticeEntity notice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new RuntimeException("Notice not found"));
 
         // 조회수 증가

--- a/src/main/java/com/hid_web/be/storage/community/NewsEventEntity.java
+++ b/src/main/java/com/hid_web/be/storage/community/NewsEventEntity.java
@@ -30,4 +30,13 @@ public class NewsEventEntity {
     @Column(nullable = false, length = 50)
     private NewsEventCategory category;
 
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "attachment_url", length = 500)
+    private String attachmentUrl;
+
+    @Column(nullable = false)
+    private int views;
+
 }

--- a/src/main/java/com/hid_web/be/storage/community/NoticeEntity.java
+++ b/src/main/java/com/hid_web/be/storage/community/NoticeEntity.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-//@Table(name = "notice")
 public class NoticeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
Description
News & Event 목록에서 특정 News & Event 항목을 클릭했을 때 상세 정보를 조회하는 기능을 개발한다.
각 News & Event 상세 조회는 제목, 작성일자, 조회수, 이미지, 카테고리, 텍스트를 포함한다.
또한, 데이터가 많아질 경우를 대비해 목록 조회에 페이징 기능을 추가하여 성능 최적화한다.

Todo
특정 뉴스이벤트 상세 조회 엔드포인트 구현
기본 페이징 처리 기능

Future
동적 페이징 및 카테고리 필터링 기능 추가

closes #37