### PR TITLE
공지사항 중요 필드 갯수 제한 기능 추가 (#39)

### DIFF
--- a/src/main/java/com/hid_web/be/InitNoticeDB.java
+++ b/src/main/java/com/hid_web/be/InitNoticeDB.java
@@ -28,7 +28,7 @@ public class InitNoticeDB {
         private final EntityManager em;
 
         public void dbInit() {
-            for (int i = 1; i <= 20; i++) {
+            for (int i = 1; i <= 14; i++) {
                 NoticeEntity notice = new NoticeEntity();
                 notice.setTitle(i % 5 == 0 ? "중요 공지사항 " + i : "일반 공지사항 " + i);
                 notice.setAuthor(i % 3 == 0 ? "TA" : "Council");

--- a/src/main/java/com/hid_web/be/controller/community/NoticeController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NoticeController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/notices")
 public class NoticeController {
@@ -24,7 +26,8 @@ public class NoticeController {
     }
 
     @GetMapping
-    public Page<NoticeResponse> getAllNotices(@PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+    public List<NoticeResponse> getAllNotices(
+            @PageableDefault(size = 12, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
         return noticeService.getAllNotices(pageable);
     }
 

--- a/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
+++ b/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
@@ -6,9 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface NoticeRepository extends JpaRepository<NoticeEntity, Long> {
-    @Query("SELECT n FROM NoticeEntity n ORDER BY n.isImportant DESC, n.createdDate DESC")
-    Page<NoticeEntity> findAllByOrderByIsImportantDescCreatedDateDesc(Pageable pageable);
+
+    List<NoticeEntity> findTop3ByIsImportantTrueOrderByCreatedDateDesc();
+
+    List<NoticeEntity> findByIsImportantFalseOrderByCreatedDateDesc(Pageable pageable);
 
 }


### PR DESCRIPTION
# Description
공지사항 목록 조회 시, 중요 공지사항을 최대 3개로 제한하여 반환하는 기능을 추가한다.
해당 기능을 통해 중요 공지사항은 항상 최신 3개만 반환되도록 구현하며, 일반 공지사항과 결합하여 총 12개의 공지가 반환되도록 한다.

# Todo
중요 공지사항을 작성일자 기준 상위 3개만 가져오는 쿼리 메서드 추가
중요 공지사항 최대 3개를 가져오고, 일반 공지사항으로 나머지 공지를 채우는 로직 구현

closes #39 