### PR TITLE
커뮤니티 조회 기능 추가(#41)

### DIFF
--- a/src/main/java/com/hid_web/be/InitCommunityDB.java
+++ b/src/main/java/com/hid_web/be/InitCommunityDB.java
@@ -2,6 +2,7 @@ package com.hid_web.be;
 
 import com.hid_web.be.domain.community.NewsEventCategory;
 import com.hid_web.be.storage.community.NewsEventEntity;
+import com.hid_web.be.storage.community.NoticeEntity;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
@@ -12,11 +13,11 @@ import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
-public class InitNewsEventDB {
+public class InitCommunityDB {
 
     private final InitService initService;
 
-    //@PostConstruct
+    @PostConstruct
     public void init() {
         initService.dbInit();
     }
@@ -29,6 +30,18 @@ public class InitNewsEventDB {
         private final EntityManager em;
 
         public void dbInit() {
+
+            for (int i = 1; i <= 10; i++) {
+                NoticeEntity notice = new NoticeEntity();
+                notice.setTitle(i % 5 == 0 ? "중요 공지사항 " + i : "일반 공지사항 " + i);
+                notice.setAuthor(i % 3 == 0 ? "TA" : "Council");
+                notice.setCreatedDate(LocalDateTime.now().minusDays(20-i));
+                notice.setViews(0);
+                notice.setAttachmentUrl(i % 4 == 0 ? "https://example.com/file" + i + ".pdf" : null);
+                notice.setImportant(i % 5 == 0);
+                em.persist(notice);
+            }
+
             for (int i = 1; i <= 10; i++) {
                 NewsEventEntity newsEvent = new NewsEventEntity();
                 newsEvent.setThumbnailUrl("https://example.com/image" + i + ".jpg");

--- a/src/main/java/com/hid_web/be/InitNoticeDB.java
+++ b/src/main/java/com/hid_web/be/InitNoticeDB.java
@@ -15,7 +15,7 @@ public class InitNoticeDB {
 
     private final InitService initService;
 
-    @PostConstruct
+    //@PostConstruct
     public void init() {
         initService.dbInit();
     }

--- a/src/main/java/com/hid_web/be/controller/community/CommunityController.java
+++ b/src/main/java/com/hid_web/be/controller/community/CommunityController.java
@@ -1,0 +1,20 @@
+package com.hid_web.be.controller.community;
+
+import com.hid_web.be.controller.community.response.CommunityResponse;
+import com.hid_web.be.domain.community.CommunityService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/community")
+@RequiredArgsConstructor
+public class CommunityController {
+    private final CommunityService communityService;
+
+    @GetMapping
+    public CommunityResponse getCommunityPage() {
+        return communityService.getCommunityData();
+    }
+}

--- a/src/main/java/com/hid_web/be/controller/community/response/CommunityResponse.java
+++ b/src/main/java/com/hid_web/be/controller/community/response/CommunityResponse.java
@@ -1,0 +1,14 @@
+package com.hid_web.be.controller.community.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommunityResponse {
+    private List<NoticeResponse> notices;
+    private List<NewsEventResponse> newsEvents;
+}

--- a/src/main/java/com/hid_web/be/domain/community/CommunityService.java
+++ b/src/main/java/com/hid_web/be/domain/community/CommunityService.java
@@ -1,0 +1,47 @@
+package com.hid_web.be.domain.community;
+
+import com.hid_web.be.controller.community.response.CommunityResponse;
+import com.hid_web.be.controller.community.response.NewsEventResponse;
+import com.hid_web.be.controller.community.response.NoticeResponse;
+import com.hid_web.be.storage.community.NewsEventEntity;
+import com.hid_web.be.storage.community.NewsEventRepository;
+import com.hid_web.be.storage.community.NoticeEntity;
+import com.hid_web.be.storage.community.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommunityService {
+    private final NoticeRepository noticeRepository;
+    private final NewsEventRepository newsEventRepository;
+
+    public CommunityResponse getCommunityData() {
+        List<NoticeEntity> importantNotices = noticeRepository.findTop1ByIsImportantTrueOrderByCreatedDateDesc();
+
+        List<NoticeEntity> generalNotices = noticeRepository.findTop5ByIsImportantFalseOrderByCreatedDateDesc();
+
+        List<NoticeEntity> allNotices = new ArrayList<>();
+        allNotices.addAll(importantNotices);
+        allNotices.addAll(generalNotices);
+
+        List<NoticeResponse> notices = allNotices.stream()
+                .map(NoticeResponse::new)
+                .collect(Collectors.toList());
+
+        List<NewsEventEntity> newsEventEntities = newsEventRepository.findTop8ByOrderByCreatedDateDesc();
+
+        List<NewsEventResponse> newsEvents = newsEventEntities.stream()
+                .map(NewsEventResponse::new)
+                .collect(Collectors.toList());
+
+        return CommunityResponse.builder()
+                .notices(notices)
+                .newsEvents(newsEvents)
+                .build();
+    }
+}

--- a/src/main/java/com/hid_web/be/storage/community/NewsEventRepository.java
+++ b/src/main/java/com/hid_web/be/storage/community/NewsEventRepository.java
@@ -3,7 +3,10 @@ package com.hid_web.be.storage.community;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface NewsEventRepository extends JpaRepository<NewsEventEntity, Long> {
+    List<NewsEventEntity> findTop8ByOrderByCreatedDateDesc();
 
 }

--- a/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
+++ b/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
@@ -15,4 +15,9 @@ public interface NoticeRepository extends JpaRepository<NoticeEntity, Long> {
 
     List<NoticeEntity> findByIsImportantFalseOrderByCreatedDateDesc(Pageable pageable);
 
+    // Community 조회
+    List<NoticeEntity> findTop1ByIsImportantTrueOrderByCreatedDateDesc();
+
+    List<NoticeEntity> findTop5ByIsImportantFalseOrderByCreatedDateDesc();
+
 }


### PR DESCRIPTION
# Description
공지사항과 뉴스이벤트를 함께 조회할 수 있는 커뮤니티 조회 기능을 개발한다.
공지사항 목록은 중요 공지 1개와 일반 공지 5개로 구성되며, 뉴스이벤트 목록은 상위 8개가 반환된다.

# Todo
요구사항에 맞는 공지사항 및 뉴스이벤트 조회 로직 추가
NoticeRepository와 NewsEventRepository를 활용한 데이터 조회 및 DTO 변환 로직 구현

# Future
페이징 기능 추가
카테고리 필터링 기능 추가

closes #41