### PR TITLE
도메인 별 목록 조회 갯수 변경에 따른 정렬 로직 수정 (#43)

### DIFF
--- a/src/main/java/com/hid_web/be/InitCommunityDB.java
+++ b/src/main/java/com/hid_web/be/InitCommunityDB.java
@@ -31,7 +31,7 @@ public class InitCommunityDB {
 
         public void dbInit() {
 
-            for (int i = 1; i <= 10; i++) {
+            for (int i = 1; i <= 20; i++) {
                 NoticeEntity notice = new NoticeEntity();
                 notice.setTitle(i % 5 == 0 ? "중요 공지사항 " + i : "일반 공지사항 " + i);
                 notice.setAuthor(i % 3 == 0 ? "TA" : "Council");
@@ -42,10 +42,10 @@ public class InitCommunityDB {
                 em.persist(notice);
             }
 
-            for (int i = 1; i <= 10; i++) {
+            for (int i = 1; i <= 20; i++) {
                 NewsEventEntity newsEvent = new NewsEventEntity();
                 newsEvent.setThumbnailUrl("https://example.com/image" + i + ".jpg");
-                newsEvent.setCreatedDate(LocalDateTime.now().minusDays(i));
+                newsEvent.setCreatedDate(LocalDateTime.now().minusDays(20-i));
                 newsEvent.setTitle("뉴스이벤트 제목 " + i);
                 newsEvent.setCategory(i % 4 == 0 ? NewsEventCategory.RECRUIT :
                         i % 4 == 1 ? NewsEventCategory.CONTEST :

--- a/src/main/java/com/hid_web/be/controller/community/NewsEventController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NewsEventController.java
@@ -21,7 +21,7 @@ public class NewsEventController {
 
     @GetMapping
     public Page<NewsEventResponse> getAllNewsEvents(
-            @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+            @PageableDefault(size = 12, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
         return newsEventService.getAllNewsEvents(pageable);
     }
 

--- a/src/main/java/com/hid_web/be/controller/community/NoticeController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NoticeController.java
@@ -26,8 +26,7 @@ public class NoticeController {
     }
 
     @GetMapping
-    public List<NoticeResponse> getAllNotices(
-            @PageableDefault(size = 12, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+    public List<NoticeResponse> getAllNotices(Pageable pageable) {
         return noticeService.getAllNotices(pageable);
     }
 

--- a/src/main/java/com/hid_web/be/domain/community/CommunityService.java
+++ b/src/main/java/com/hid_web/be/domain/community/CommunityService.java
@@ -23,7 +23,7 @@ public class CommunityService {
     public CommunityResponse getCommunityData() {
         List<NoticeEntity> importantNotices = noticeRepository.findTop1ByIsImportantTrueOrderByCreatedDateDesc();
 
-        List<NoticeEntity> generalNotices = noticeRepository.findTop5ByIsImportantFalseOrderByCreatedDateDesc();
+        List<NoticeEntity> generalNotices = noticeRepository.findTop4ByIsImportantFalseOrderByCreatedDateDesc();
 
         List<NoticeEntity> allNotices = new ArrayList<>();
         allNotices.addAll(importantNotices);

--- a/src/main/java/com/hid_web/be/storage/community/NewsEventRepository.java
+++ b/src/main/java/com/hid_web/be/storage/community/NewsEventRepository.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 @Repository
 public interface NewsEventRepository extends JpaRepository<NewsEventEntity, Long> {
+
+    // Community 조회
     List<NewsEventEntity> findTop8ByOrderByCreatedDateDesc();
 
 }

--- a/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
+++ b/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Repository
 public interface NoticeRepository extends JpaRepository<NoticeEntity, Long> {
 
+    // Notice 조회
     List<NoticeEntity> findTop3ByIsImportantTrueOrderByCreatedDateDesc();
 
     List<NoticeEntity> findByIsImportantFalseOrderByCreatedDateDesc(Pageable pageable);
@@ -18,6 +19,6 @@ public interface NoticeRepository extends JpaRepository<NoticeEntity, Long> {
     // Community 조회
     List<NoticeEntity> findTop1ByIsImportantTrueOrderByCreatedDateDesc();
 
-    List<NoticeEntity> findTop5ByIsImportantFalseOrderByCreatedDateDesc();
+    List<NoticeEntity> findTop4ByIsImportantFalseOrderByCreatedDateDesc();
 
 }


### PR DESCRIPTION
# Description
Notice - 중요 공지 최대 3개, 일반 공지 9개
NewsEvent - 12개
Community - Notice (중요 공지 최대 1개, 일반 공지 4개), NewsEvent(8개)

# Todo
Repository 계층에서 요구사항에 맞는 정렬 로직 수정

closes #43 