### PR TITLE
공지사항 정렬 로직 수정 및 공지사항과 뉴스이벤트 목록에 대한 페이지네이션 기능 추가 (#47)

### DIFF
--- a/src/main/java/com/hid_web/be/controller/community/NewsEventController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NewsEventController.java
@@ -5,7 +5,10 @@ import com.hid_web.be.controller.community.response.NewsEventResponse;
 import com.hid_web.be.domain.community.NewsEventService;
 import com.hid_web.be.storage.community.NewsEventEntity;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -21,7 +24,11 @@ public class NewsEventController {
     private final NewsEventService newsEventService;
 
     @GetMapping
-    public List<NewsEventResponse> getAllNewsEvents(Pageable pageable) {
+    public Page<NewsEventResponse> getAllNewsEvents(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "12") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdDate").descending());
         return newsEventService.getAllNewsEvents(pageable);
     }
 

--- a/src/main/java/com/hid_web/be/controller/community/NoticeController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NoticeController.java
@@ -4,7 +4,10 @@ import com.hid_web.be.controller.community.response.NoticeDetailResponse;
 import com.hid_web.be.controller.community.response.NoticeResponse;
 import com.hid_web.be.domain.community.NoticeService;
 import com.hid_web.be.storage.community.NoticeEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -23,7 +26,11 @@ public class NoticeController {
     }
 
     @GetMapping
-    public List<NoticeResponse> getAllNotices(Pageable pageable) {
+    public Page<NoticeResponse> getAllNotices(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "12") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdDate").descending());
         return noticeService.getAllNotices(pageable);
     }
 

--- a/src/main/java/com/hid_web/be/domain/community/NewsEventService.java
+++ b/src/main/java/com/hid_web/be/domain/community/NewsEventService.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,19 +23,10 @@ public class NewsEventService {
     private final NewsEventRepository newsEventRepository;
     private final S3Uploader s3Uploader;
 
-    public List<NewsEventResponse> getAllNewsEvents(Pageable pageable) {
+    public Page<NewsEventResponse> getAllNewsEvents(Pageable pageable) {
         return newsEventRepository.findTop12ByOrderByCreatedDateDescIdDesc(pageable)
-                .stream()
-                .map(NewsEventResponse::new)
-                .collect(Collectors.toList());
+                .map(NewsEventResponse::new);
     }
-
-//    public Page<NewsEventResponse> getAllNewsEvents(Pageable pageable) {
-//        return newsEventRepository.findTop12ByOrderByCreatedDateDescIdAsc()
-//                .stream()
-//                .map(NewsEventResponse::new)
-//                .collect(Collectors.toList());
-//    }
 
     public NewsEventDetailResponse getNewsEventDetail(Long newsEventId) {
         NewsEventEntity newsEvent = newsEventRepository.findById(newsEventId)

--- a/src/main/java/com/hid_web/be/storage/community/NewsEventRepository.java
+++ b/src/main/java/com/hid_web/be/storage/community/NewsEventRepository.java
@@ -1,5 +1,6 @@
 package com.hid_web.be.storage.community;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,7 +11,7 @@ import java.util.List;
 public interface NewsEventRepository extends JpaRepository<NewsEventEntity, Long> {
 
     // NewsEvent 조회
-    List<NewsEventEntity> findTop12ByOrderByCreatedDateDescIdDesc(Pageable pageable);
+    Page<NewsEventEntity> findTop12ByOrderByCreatedDateDescIdDesc(Pageable pageable);
 
     // Community 조회
     List<NewsEventEntity> findTop8ByOrderByCreatedDateDescIdDesc();

--- a/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
+++ b/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
@@ -3,7 +3,6 @@ package com.hid_web.be.storage.community;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,11 +13,11 @@ public interface NoticeRepository extends JpaRepository<NoticeEntity, Long> {
     // Notice 조회
     List<NoticeEntity> findTop3ByIsImportantTrueOrderByCreatedDateDescIdDesc();
 
-    List<NoticeEntity> findByIsImportantFalseOrderByCreatedDateDescIdDesc(Pageable pageable);
+    Page<NoticeEntity> findAllByOrderByCreatedDateDescIdDesc(Pageable pageable);
+
 
     // Community 조회
     List<NoticeEntity> findTop1ByIsImportantTrueOrderByCreatedDateDesc();
 
     List<NoticeEntity> findTop4ByIsImportantFalseOrderByCreatedDateDescIdDesc();
-
 }


### PR DESCRIPTION
# Description
공지사항 및 뉴스이벤트 목록 조회 시, 데이터가 많아질 경우를 대비하여 효율적인 페이지네이션 기능을 구현한다.

# Todo
- 정렬 로직 수정
1. 중복된 데이터 조회에 따른 중복 제거 로직 수정

- 페이지네이션
1. 공지사항과 뉴스이벤트 도메인에 Pageable 객체를 활용하여 데이터 정보 반환

closes #47 