### PR TITLE
공지사항 생성, 수정, 삭제 API 구현 및 S3 로직 수정 (#49)

### DIFF
--- a/src/main/java/com/hid_web/be/InitCommunityDB.java
+++ b/src/main/java/com/hid_web/be/InitCommunityDB.java
@@ -1,6 +1,7 @@
 package com.hid_web.be;
 
 import com.hid_web.be.domain.community.NewsEventCategory;
+import com.hid_web.be.domain.community.NoticeAuthorType;
 import com.hid_web.be.storage.community.NewsEventEntity;
 import com.hid_web.be.storage.community.NoticeEntity;
 import jakarta.annotation.PostConstruct;
@@ -35,7 +36,7 @@ public class InitCommunityDB {
             NoticeEntity notice = NoticeEntity.builder()
                     .uuid("notice-uuid-123")
                     .title("공지사항 예제")
-                    .author("Admin")
+                    .author(NoticeAuthorType.valueOf("TA"))
                     .createdDate(LocalDate.now())
                     .content("공지사항 본문 내용입니다.")
                     .views(0)

--- a/src/main/java/com/hid_web/be/controller/community/NoticeController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NoticeController.java
@@ -1,29 +1,29 @@
 package com.hid_web.be.controller.community;
 
+import com.hid_web.be.controller.community.request.CreateNoticeRequest;
+import com.hid_web.be.controller.community.request.UpdateNoticeRequest;
 import com.hid_web.be.controller.community.response.NoticeDetailResponse;
 import com.hid_web.be.controller.community.response.NoticeResponse;
 import com.hid_web.be.domain.community.NoticeService;
 import com.hid_web.be.storage.community.NoticeEntity;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
 
 @RestController
 @RequestMapping("/notices")
+@RequiredArgsConstructor
 public class NoticeController {
 
     private final NoticeService noticeService;
-
-    public NoticeController(NoticeService noticeService) {
-        this.noticeService = noticeService;
-    }
 
     @GetMapping
     public Page<NoticeResponse> getAllNotices(
@@ -41,24 +41,28 @@ public class NoticeController {
     }
 
     @PostMapping
-    public ResponseEntity<NoticeEntity> createNotice(
-            @RequestParam("title") String title,
-            @RequestParam("author") String author,
-            @RequestParam(value = "images", required = false) List<MultipartFile> images,
-            @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments,
-            @RequestParam("content") String content,
-            @RequestParam(value = "isImportant", defaultValue = "false") boolean isImportant
-    ) throws IOException {
-        // 빈 파일 필터링
-        images = images != null ? images.stream().filter(file -> !file.isEmpty()).toList() : null;
-        attachments = attachments != null ? attachments.stream().filter(file -> !file.isEmpty()).toList() : null;
+    public ResponseEntity<NoticeEntity> createNotice(@Valid @ModelAttribute CreateNoticeRequest request) throws IOException {
+        return ResponseEntity.ok(noticeService.createNotice(request));
+    }
 
-        return ResponseEntity.ok(noticeService.createNotice(title, author, images, attachments, content, isImportant));
+    @PutMapping("/{id}")
+    public ResponseEntity<NoticeEntity> updateNotice(
+            @PathVariable Long id,
+            @Valid @ModelAttribute UpdateNoticeRequest request
+    ) throws IOException {
+        return ResponseEntity.ok(noticeService.updateNotice(id, request));
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteNotice(@PathVariable Long id) {
         noticeService.deleteNotice(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 복수개 공지사항 삭제
+    @DeleteMapping
+    public ResponseEntity<Void> deleteNotices(@RequestParam List<Long> noticeIds) {
+        noticeService.deleteNotices(noticeIds);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/hid_web/be/controller/community/request/CreateNoticeRequest.java
+++ b/src/main/java/com/hid_web/be/controller/community/request/CreateNoticeRequest.java
@@ -1,0 +1,34 @@
+package com.hid_web.be.controller.community.request;
+
+import com.hid_web.be.domain.community.NoticeAuthorType;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class CreateNoticeRequest {
+    @NotBlank(message = "제목은 필수 입력 값입니다.")
+    private String title;
+    private String content;
+    @NotBlank(message = "작성자는 필수 입력 값입니다.")
+    private String author;
+    private Boolean isImportant;
+    private List<MultipartFile> images;
+    private List<MultipartFile> attachments;
+
+    public NoticeAuthorType getAuthorEnum() {
+        try {
+            return NoticeAuthorType.valueOf(this.author.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("잘못된 작성자(author) 값입니다. [가능한 값: TA, COUNCIL]");
+        }
+    }
+
+    public boolean getIsImportant() {
+        return Boolean.TRUE.equals(this.isImportant);
+    }
+}

--- a/src/main/java/com/hid_web/be/controller/community/request/UpdateNoticeRequest.java
+++ b/src/main/java/com/hid_web/be/controller/community/request/UpdateNoticeRequest.java
@@ -1,0 +1,30 @@
+package com.hid_web.be.controller.community.request;
+
+import com.hid_web.be.domain.community.NoticeAuthorType;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class UpdateNoticeRequest {
+    @NotBlank(message = "제목은 필수 입력 값입니다.")
+    private String title;
+    private String content;
+    @NotBlank(message = "작성자는 필수 입력 값입니다.")
+    private String author;
+    private Boolean isImportant;
+    private List<MultipartFile> images;
+    private List<MultipartFile> attachments;
+
+    public NoticeAuthorType getAuthorEnum() {
+        return NoticeAuthorType.valueOf(this.author.toUpperCase()); // 문자열을 Enum으로 변환
+    }
+
+    public boolean getIsImportant() {
+        return this.isImportant != null ? this.isImportant : false;
+    }
+}

--- a/src/main/java/com/hid_web/be/controller/community/response/NoticeDetailResponse.java
+++ b/src/main/java/com/hid_web/be/controller/community/response/NoticeDetailResponse.java
@@ -24,7 +24,7 @@ public class NoticeDetailResponse {
     public NoticeDetailResponse(NoticeEntity entity) {
         this.id = entity.getId();
         this.title = entity.getTitle();
-        this.author = entity.getAuthor();
+        this.author = entity.getAuthor().name();
         this.createdDate = entity.getCreatedDate();
         this.views = entity.getViews();
         this.attachmentUrls = entity.getAttachmentUrls();

--- a/src/main/java/com/hid_web/be/controller/community/response/NoticeResponse.java
+++ b/src/main/java/com/hid_web/be/controller/community/response/NoticeResponse.java
@@ -21,7 +21,7 @@ public class NoticeResponse {
     public NoticeResponse(NoticeEntity entity) {
         this.id = entity.getId();
         this.title = entity.getTitle();
-        this.author = entity.getAuthor();
+        this.author = entity.getAuthor().name();
         this.createdDate = entity.getCreatedDate();
         this.attachmentUrls = entity.getAttachmentUrls();
         this.isImportant = entity.isImportant();

--- a/src/main/java/com/hid_web/be/domain/community/NoticeAuthorType.java
+++ b/src/main/java/com/hid_web/be/domain/community/NoticeAuthorType.java
@@ -1,0 +1,5 @@
+package com.hid_web.be.domain.community;
+
+public enum NoticeAuthorType {
+    TA, Council
+}

--- a/src/main/java/com/hid_web/be/domain/s3/S3Uploader.java
+++ b/src/main/java/com/hid_web/be/domain/s3/S3Uploader.java
@@ -71,12 +71,16 @@ public class S3Uploader {
         );
     }
 
-    // 다중 파일 삭제 (S3)
+    // 다중 파일 삭제
     public void deleteFiles(List<String> fileUrls) {
-        if (fileUrls != null && !fileUrls.isEmpty()) {
-            for (String fileUrl : fileUrls) {
-                deleteFile(fileUrl);
-            }
+        if (fileUrls == null || fileUrls.isEmpty()) return;
+
+        for (String fileUrl : fileUrls) {
+            String key = fileUrl.replace("https://" + bucketName + ".s3.amazonaws.com/", "");
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build());
         }
     }
 

--- a/src/main/java/com/hid_web/be/storage/community/NoticeEntity.java
+++ b/src/main/java/com/hid_web/be/storage/community/NoticeEntity.java
@@ -1,5 +1,6 @@
 package com.hid_web.be.storage.community;
 
+import com.hid_web.be.domain.community.NoticeAuthorType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,8 +27,9 @@ public class NoticeEntity {
     @Column(nullable = false, length = 255)
     private String title;
 
-    @Column(nullable = false)
-    private String author;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "author", nullable = false)
+    private NoticeAuthorType author;
 
     @Column(name = "created_date", nullable = false)
     private LocalDate createdDate;
@@ -50,4 +52,5 @@ public class NoticeEntity {
 
     @Column(name = "is_important", nullable = false)
     private boolean isImportant;
+
 }


### PR DESCRIPTION
# Description
공지사항 도메인의 생성, 수정, 삭제 API를 구현하고 S3 이미지 및 첨부파일의 중복 저장 관리 로직을 수정한다.

# Todo
공지사항 생성, 수정, 삭제

제목, 작성자, 내용, 중요공지 여부, 이미지, 첨부파일을 포함하여 공지 작성
필수 값(제목, 작성자) 유효성 검사 로직 구현
S3 이미지 및 첨부파일 관리 로직

기존 파일과 새로운 파일의 중복 저장 로직 수정 -> 기존 파일 삭제 후, 새로운 파일 업로드

closes #49 