### PR TITLE
S3 객체의 접근 권한 변경 및 업로드시 파일 타입에 따라 메타데이터값 동적 설정 (#52)

### DIFF
--- a/src/main/java/com/hid_web/be/domain/s3/S3Uploader.java
+++ b/src/main/java/com/hid_web/be/domain/s3/S3Uploader.java
@@ -10,9 +10,7 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -48,10 +46,17 @@ public class S3Uploader {
 
     // S3 업로드 로직
     private String uploadToS3(MultipartFile file, String objectKey) throws IOException {
+        String contentType = file.getContentType();
+        if (contentType == null) {
+            contentType = "application/octet-stream";
+        }
+
+        // S3 업로드 요청
         s3Client.putObject(
                 PutObjectRequest.builder()
                         .bucket(bucketName)
                         .key(objectKey)
+                        .contentType(contentType)
                         .build(),
                 RequestBody.fromBytes(file.getBytes())
         );


### PR DESCRIPTION
# Description
API 연동시 발생한 이미지 접근 거부 오류로 인해 이미지 렌더링이 되지 않는 문제를 해결한다.

# Todo
- S3 CORS 권한 설정 추가
```
[
  {
    "AllowedHeaders": ["*"],
    "AllowedMethods": ["GET"],
    "AllowedOrigins": ["*"],
    "ExposeHeaders": []
  }
]
```

- S3 퍼블릭 접근 정책 추가

```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": "*",
      "Action": "s3:GetObject",
      "Resource": "arn:aws:s3:::hid-bucket/*"
    }
  ]
}
```

- 원활한 이미지 렌더링을 위해 Content-Type을 명시적으로 설정 하여 각각의 파일에 맞게 업로드 요청

close #52 