### PR TITLE
공지사항 중요공지 로직 및 페이지네이션 리팩토링 (#51)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3' // S3 연동
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store' // Parameter Store 연동
 	implementation 'org.springframework.boot:spring-boot-starter-validation' // 유효성 검사
+	implementation 'commons-io:commons-io:2.11.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/hid_web/be/controller/community/NoticeController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NoticeController.java
@@ -2,6 +2,7 @@ package com.hid_web.be.controller.community;
 
 import com.hid_web.be.controller.community.request.CreateNoticeRequest;
 import com.hid_web.be.controller.community.request.UpdateNoticeRequest;
+import com.hid_web.be.controller.community.response.CustomPageResponse;
 import com.hid_web.be.controller.community.response.NoticeDetailResponse;
 import com.hid_web.be.controller.community.response.NoticeResponse;
 import com.hid_web.be.domain.community.NoticeService;
@@ -16,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.List;
 
 @RestController
@@ -26,18 +28,23 @@ public class NoticeController {
     private final NoticeService noticeService;
 
     @GetMapping
-    public Page<NoticeResponse> getAllNotices(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "12") int size
+    public CustomPageResponse<NoticeResponse> getAllNotices(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
     ) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("createdDate").descending());
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdDate").descending());
         return noticeService.getAllNotices(pageable);
     }
 
     @GetMapping("/{noticeId}")
     public ResponseEntity<NoticeDetailResponse> getNoticeDetail(@PathVariable Long noticeId) {
-        NoticeDetailResponse response = noticeService.getNoticeDetail(noticeId);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(noticeService.getNoticeDetail(noticeId));
+    }
+
+    // 공지사항 첨부파일 ZIP 다운로드 API 추가
+    @GetMapping("/{noticeId}/download-attachments")
+    public ResponseEntity<byte[]> downloadAttachments(@PathVariable Long noticeId) throws IOException, URISyntaxException {
+        return noticeService.downloadAllAttachmentsAsZip(noticeId);
     }
 
     @PostMapping

--- a/src/main/java/com/hid_web/be/controller/community/response/CustomPageResponse.java
+++ b/src/main/java/com/hid_web/be/controller/community/response/CustomPageResponse.java
@@ -1,0 +1,23 @@
+package com.hid_web.be.controller.community.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CustomPageResponse<T> {
+    private List<T> content;
+    private PageInfo pageInfo;
+
+    @Getter
+    @AllArgsConstructor
+    public static class PageInfo {
+        private int currentPage;    // 현재 페이지 (1부터 시작)
+        private int totalPages;     // 전체 페이지 수
+        private long totalElements; // 전체 데이터 개수
+        private boolean isFirst;    // 첫 번째 페이지 여부
+        private boolean isLast;     // 마지막 페이지 여부
+    }
+}

--- a/src/main/java/com/hid_web/be/domain/community/NewsEventService.java
+++ b/src/main/java/com/hid_web/be/domain/community/NewsEventService.java
@@ -5,7 +5,7 @@ import com.hid_web.be.controller.community.response.NewsEventResponse;
 import com.hid_web.be.domain.s3.S3Uploader;
 import com.hid_web.be.storage.community.NewsEventEntity;
 import com.hid_web.be.storage.community.NewsEventRepository;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/hid_web/be/domain/s3/S3Uploader.java
+++ b/src/main/java/com/hid_web/be/domain/s3/S3Uploader.java
@@ -1,18 +1,32 @@
 package com.hid_web.be.domain.s3;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 @Service
 @RequiredArgsConstructor
@@ -28,9 +42,25 @@ public class S3Uploader {
             return null;
         }
 
-        String uuid = UUID.randomUUID().toString();
-        String objectKey = folderPath + "/" + uuid + "_" + file.getOriginalFilename();
-        return uploadToS3(file, objectKey);
+        // 파일명 안전하게 인코딩 (공백 처리 포함)
+        String encodedOriginalFileName = URLEncoder.encode(file.getOriginalFilename(), StandardCharsets.UTF_8)
+                .replaceAll("\\+", "%20");
+
+        String randomFileName = UUID.randomUUID().toString();
+        String objectKey = folderPath + "/" + randomFileName + "_" + encodedOriginalFileName;
+
+        // S3 업로드
+        s3Client.putObject(
+                PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(objectKey)
+                        .contentType(file.getContentType())
+                        .build(),
+                RequestBody.fromBytes(file.getBytes())
+        );
+
+        // 업로드된 파일 URL 반환
+        return "https://" + bucketName + ".s3.amazonaws.com/" + objectKey;
     }
 
     // 다중 파일 업로드 (빈 파일 검증 추가)
@@ -47,29 +77,75 @@ public class S3Uploader {
     }
 
     // S3 업로드 로직
-    private String uploadToS3(MultipartFile file, String objectKey) throws IOException {
+    private String uploadToS3(MultipartFile file, String folderPath) throws IOException {
+        // 파일명 인코딩 및 공백 처리
+        String encodedFileName = URLEncoder.encode(file.getOriginalFilename(), StandardCharsets.UTF_8.toString())
+                .replaceAll("\\+", "%20"); // 공백을 %20으로 변환
+
+        // 무작위 UUID로 안전한 파일명 생성 (보안 강화)
+        String randomFileName = UUID.randomUUID().toString();
+
+        // S3에 저장될 object key 생성
+        String objectKey = folderPath + "/" + randomFileName;
+
+        // S3에 파일 업로드
         s3Client.putObject(
                 PutObjectRequest.builder()
                         .bucket(bucketName)
                         .key(objectKey)
+                        .contentType(file.getContentType()) // 파일 형식 설정
                         .build(),
                 RequestBody.fromBytes(file.getBytes())
         );
 
+        // 업로드된 파일 URL 반환
         return "https://" + bucketName + ".s3.amazonaws.com/" + objectKey;
     }
 
-    // 단일 파일 삭제 (S3)
-    public void deleteFile(String fileUrl) {
+    // 여러 개의 S3 파일을 ZIP으로 묶어 다운로드
+    public byte[] downloadAllAsZip(List<String> fileUrls) throws IOException, URISyntaxException {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+        // 한글 파일명을 위한 UTF-8 인코딩 설정
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(byteArrayOutputStream, Charset.forName("UTF-8"))) {
+            for (String fileUrl : fileUrls) {
+                String originalFileName = extractOriginalFileNameFromUrl(fileUrl);
+                byte[] fileData = downloadFileFromS3(fileUrl);
+
+                ZipEntry zipEntry = new ZipEntry(originalFileName);
+                zipOutputStream.putNextEntry(zipEntry);
+                zipOutputStream.write(fileData);
+                zipOutputStream.closeEntry();
+            }
+        }
+        return byteArrayOutputStream.toByteArray();
+    }
+
+    // S3에서 개별 파일 다운로드
+    private byte[] downloadFileFromS3(String fileUrl) throws IOException, URISyntaxException {
         String objectKey = extractObjectKeyFromUrl(fileUrl);
 
-        s3Client.deleteObject(
-                DeleteObjectRequest.builder()
-                        .bucket(bucketName)
-                        .key(objectKey)
-                        .build()
-        );
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(objectKey)
+                .build();
+
+        try (ResponseInputStream<GetObjectResponse> s3Object = s3Client.getObject(getObjectRequest)) {
+            return IOUtils.toByteArray(s3Object); // 파일 데이터 읽기
+        }
     }
+
+//    // 단일 파일 삭제 (S3)
+//    public void deleteFile(String fileUrl) {
+//        String objectKey = extractObjectKeyFromUrl(fileUrl);
+//
+//        s3Client.deleteObject(
+//                DeleteObjectRequest.builder()
+//                        .bucket(bucketName)
+//                        .key(objectKey)
+//                        .build()
+//        );
+//    }
 
     // 다중 파일 삭제
     public void deleteFiles(List<String> fileUrls) {
@@ -84,10 +160,55 @@ public class S3Uploader {
         }
     }
 
-    // S3 URL에서 Object Key 추출
-    private String extractObjectKeyFromUrl(String fileUrl) {
-        return fileUrl.substring(fileUrl.indexOf(".com/") + 5);
-        // 예: https://bucket-name.s3.amazonaws.com/folder/uuid_file.jpg → folder/uuid_file.jpg
+//    // S3 URL에서 Object Key 추출
+//    private String extractObjectKeyFromUrl(String fileUrl) {
+//        try {
+//            URI uri = new URI(fileUrl);
+//            return uri.getPath().substring(1); // 앞의 '/' 제거
+//        } catch (URISyntaxException e) {
+//            throw new IllegalArgumentException("잘못된 파일 URL 형식입니다: " + fileUrl, e);
+//        }
+//    }
+
+    private String extractObjectKeyFromUrl(String fileUrl) throws URISyntaxException {
+        URI uri = new URI(fileUrl);
+        String path = uri.getPath(); // 예: "/notice/uuid/attachments/파일명"
+
+        // 첫 번째 "/" 제거 후 반환
+        return path.startsWith("/") ? path.substring(1) : path;
     }
+
+
+    private String extractFileNameFromUrl(String fileUrl) {
+        try {
+            // URL에서 파일명 부분만 추출
+            URI uri = new URI(fileUrl);
+            String path = uri.getPath(); // "/bucket-name/folder/filename.ext"
+
+            return path.substring(path.lastIndexOf("/") + 1);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("잘못된 파일 URL 형식입니다: " + fileUrl, e);
+        }
+    }
+
+    private String extractOriginalFileNameFromUrl(String fileUrl) {
+        String encodedFileName = fileUrl.substring(fileUrl.lastIndexOf("_") + 1);
+        try {
+            return URLDecoder.decode(encodedFileName, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("파일명 디코딩 오류", e);
+        }
+    }
+
+    // 한글 파일명을 올바르게 변환하는 메서드
+    private String encodeFileName(String fileName) {
+        try {
+            return URLEncoder.encode(fileName, StandardCharsets.UTF_8.toString())
+                    .replaceAll("\\+", "%20"); // 공백 처리
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("파일명 인코딩 오류", e);
+        }
+    }
+
 
 }

--- a/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
+++ b/src/main/java/com/hid_web/be/storage/community/NoticeRepository.java
@@ -13,11 +13,18 @@ public interface NoticeRepository extends JpaRepository<NoticeEntity, Long> {
     // Notice 조회
     List<NoticeEntity> findTop3ByIsImportantTrueOrderByCreatedDateDescIdDesc();
 
-    Page<NoticeEntity> findAllByOrderByCreatedDateDescIdDesc(Pageable pageable);
+    // 일반 공지 조회
+    Page<NoticeEntity> findByIsImportantFalseOrderByCreatedDateDescIdDesc(Pageable pageable);
+
+    // 오래된 중요 공지 조회
+    List<NoticeEntity> findByIsImportantTrueOrderByCreatedDateAscIdAsc();
+
+    long countByIsImportantFalse();
 
 
     // Community 조회
     List<NoticeEntity> findTop1ByIsImportantTrueOrderByCreatedDateDesc();
 
     List<NoticeEntity> findTop4ByIsImportantFalseOrderByCreatedDateDescIdDesc();
+
 }


### PR DESCRIPTION
# Description
공지사항 도메인의 중요공지 처리 로직을 리팩토링하여 중요공지 개수 제한을 유지하면서 자동으로 가장 오래된 중요공지를 일반 공지로 변경하는 기능으로 수정한다. 또한 페이지네이션을 위한 응답 필드를 간소화한다.

# Todo
중요공지 개수 제한 로직 리팩토링
- 중요공지는 최대 3개까지만 가능
- 기존 중요공지 개수가 3개 일 때, 새로운 중요공지가 생성될 경우 가장 오래된 중요공지 자동 해제후 중요필드 false로 변경

페이지네이션
- `currentPage, totalPages, totalElements, first, last` 필드로 응답 데이터 간소화

closes #51 