### PR TITLE
뉴스이벤트 생성, 수정, 삭제 API 구현 (#55)

### DIFF
--- a/src/main/java/com/hid_web/be/controller/community/NewsEventController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NewsEventController.java
@@ -1,21 +1,22 @@
 package com.hid_web.be.controller.community;
 
+import com.hid_web.be.controller.community.request.CreateNewsEventRequest;
+import com.hid_web.be.controller.community.request.UpdateNewsEventRequest;
+import com.hid_web.be.controller.community.response.CustomPageResponse;
 import com.hid_web.be.controller.community.response.NewsEventDetailResponse;
 import com.hid_web.be.controller.community.response.NewsEventResponse;
 import com.hid_web.be.domain.community.NewsEventService;
-import com.hid_web.be.storage.community.NewsEventEntity;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/newsEvent")
@@ -24,7 +25,7 @@ public class NewsEventController {
     private final NewsEventService newsEventService;
 
     @GetMapping
-    public Page<NewsEventResponse> getAllNewsEvents(
+    public CustomPageResponse<NewsEventResponse> getAllNewsEvents(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "12") int size
     ) {
@@ -38,37 +39,27 @@ public class NewsEventController {
     }
 
     @PostMapping
-    public ResponseEntity<NewsEventEntity> createNewsEvent(
-            @RequestParam("title") String title,
-            @RequestParam("category") String category,
-            @RequestParam(value = "thumbnail", required = false) MultipartFile thumbnail,
-            @RequestParam(value = "images", required = false) List<MultipartFile> images,
-            @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments,
-            @RequestParam("content") String content
-    ) throws IOException {
-        // 빈 파일 검증 추가
-        if (thumbnail != null && thumbnail.isEmpty()) {
-            thumbnail = null;  // 빈 파일이면 null 처리
-        }
+    public ResponseEntity<NewsEventDetailResponse> createNewsEvent(@ModelAttribute @Valid CreateNewsEventRequest request) throws IOException {
+        return ResponseEntity.ok(newsEventService.createNewsEvent(request));
+    }
 
-        if (images != null) {
-            images = images.stream()
-                    .filter(file -> file != null && !file.isEmpty())  // 빈 파일 필터링
-                    .collect(Collectors.toList());
-        }
-
-        if (attachments != null) {
-            attachments = attachments.stream()
-                    .filter(file -> file != null && !file.isEmpty())  // 빈 파일 필터링
-                    .collect(Collectors.toList());
-        }
-
-        return ResponseEntity.ok(newsEventService.createNewsEvent(title, category, thumbnail, images, attachments, content));
+    @PutMapping("/{id}")
+    public ResponseEntity<NewsEventDetailResponse> updateNewsEvent(
+            @PathVariable Long id,
+            @ModelAttribute @Valid UpdateNewsEventRequest request
+    ) throws IOException, URISyntaxException {
+        return ResponseEntity.ok(newsEventService.updateNewsEvent(id, request));
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteNewsEvent(@PathVariable Long id) {
         newsEventService.deleteNewsEvent(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteNewsEvents(@RequestParam List<Long> newsEventIds) {
+        newsEventService.deleteNewsEvents(newsEventIds);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/hid_web/be/controller/community/NoticeController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NoticeController.java
@@ -9,7 +9,6 @@ import com.hid_web.be.domain.community.NoticeService;
 import com.hid_web.be.storage.community.NoticeEntity;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;

--- a/src/main/java/com/hid_web/be/controller/community/request/CreateNewsEventRequest.java
+++ b/src/main/java/com/hid_web/be/controller/community/request/CreateNewsEventRequest.java
@@ -1,0 +1,26 @@
+package com.hid_web.be.controller.community.request;
+
+import com.hid_web.be.domain.community.NewsEventCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class CreateNewsEventRequest {
+    @NotBlank(message = "제목은 필수 입력 값입니다.")
+    private String title;
+
+    @NotNull(message = "카테고리는 필수 입력 값입니다.")
+    private NewsEventCategory category;
+
+    private String content;
+
+    private MultipartFile thumbnail;
+    private List<MultipartFile> images;
+    private List<MultipartFile> attachments;
+}

--- a/src/main/java/com/hid_web/be/controller/community/request/UpdateNewsEventRequest.java
+++ b/src/main/java/com/hid_web/be/controller/community/request/UpdateNewsEventRequest.java
@@ -1,0 +1,26 @@
+package com.hid_web.be.controller.community.request;
+
+import com.hid_web.be.domain.community.NewsEventCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class UpdateNewsEventRequest {
+    @NotBlank(message = "제목은 필수 입력 값입니다.")
+    private String title;
+
+    @NotNull(message = "카테고리는 필수 입력 값입니다.")
+    private NewsEventCategory category;
+
+    private String content;
+
+    private MultipartFile thumbnail;
+    private List<MultipartFile> images;
+    private List<MultipartFile> attachments;
+}

--- a/src/main/java/com/hid_web/be/domain/community/NewsEventService.java
+++ b/src/main/java/com/hid_web/be/domain/community/NewsEventService.java
@@ -1,5 +1,8 @@
 package com.hid_web.be.domain.community;
 
+import com.hid_web.be.controller.community.request.CreateNewsEventRequest;
+import com.hid_web.be.controller.community.request.UpdateNewsEventRequest;
+import com.hid_web.be.controller.community.response.CustomPageResponse;
 import com.hid_web.be.controller.community.response.NewsEventDetailResponse;
 import com.hid_web.be.controller.community.response.NewsEventResponse;
 import com.hid_web.be.domain.s3.S3Uploader;
@@ -10,12 +13,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,9 +27,19 @@ public class NewsEventService {
     private final NewsEventRepository newsEventRepository;
     private final S3Uploader s3Uploader;
 
-    public Page<NewsEventResponse> getAllNewsEvents(Pageable pageable) {
-        return newsEventRepository.findTop12ByOrderByCreatedDateDescIdDesc(pageable)
-                .map(NewsEventResponse::new);
+    public CustomPageResponse<NewsEventResponse> getAllNewsEvents(Pageable pageable) {
+        Page<NewsEventEntity> newsEventPage = newsEventRepository.findTop12ByOrderByCreatedDateDescIdDesc(pageable);
+        List<NewsEventResponse> content = newsEventPage.stream()
+                .map(NewsEventResponse::new)
+                .collect(Collectors.toList());
+
+        return new CustomPageResponse<>(content, new CustomPageResponse.PageInfo(
+                newsEventPage.getNumber() + 1,
+                newsEventPage.getTotalPages(),
+                newsEventPage.getTotalElements(),
+                newsEventPage.isFirst(),
+                newsEventPage.isLast()
+        ));
     }
 
     public NewsEventDetailResponse getNewsEventDetail(Long newsEventId) {
@@ -38,31 +52,62 @@ public class NewsEventService {
     }
 
     @Transactional
-    public NewsEventEntity createNewsEvent(String title, String category, MultipartFile thumbnail,
-                                           List<MultipartFile> images, List<MultipartFile> attachments,
-                                           String content) throws IOException {
-
-        String newsEventUUID = UUID.randomUUID().toString();  // UUID 생성
+    public NewsEventDetailResponse createNewsEvent(CreateNewsEventRequest request) throws IOException {
+        String newsEventUUID = UUID.randomUUID().toString();
 
         // S3 업로드
-        String thumbnailUrl = thumbnail != null ? s3Uploader.uploadFile(thumbnail, "newsEvent/" + newsEventUUID + "/thumbnails") : null;
-        List<String> imageUrls = images != null ? s3Uploader.uploadFiles(images, "newsEvent/" + newsEventUUID + "/images") : null;
-        List<String> attachmentUrls = attachments != null ? s3Uploader.uploadFiles(attachments, "newsEvent/" + newsEventUUID + "/attachments") : null;
+        String thumbnailUrl = request.getThumbnail() != null ?
+                s3Uploader.uploadFile(request.getThumbnail(), "newsEvent/" + newsEventUUID + "/thumbnails") : null;
+
+        List<String> imageUrls = request.getImages() != null ?
+                s3Uploader.uploadFiles(request.getImages(), "newsEvent/" + newsEventUUID + "/images") : null;
+
+        List<String> attachmentUrls = request.getAttachments() != null ?
+                s3Uploader.uploadFiles(request.getAttachments(), "newsEvent/" + newsEventUUID + "/attachments") : null;
 
         // DB 저장
-        NewsEventEntity newsEvent = NewsEventEntity.builder()
+        NewsEventEntity newsEvent = newsEventRepository.save(NewsEventEntity.builder()
                 .uuid(newsEventUUID)
-                .title(title)
-                .category(NewsEventCategory.valueOf(category))
+                .title(request.getTitle())
+                .category(request.getCategory())
                 .createdDate(LocalDate.now())
                 .thumbnailUrl(thumbnailUrl)
                 .imageUrls(imageUrls)
                 .attachmentUrls(attachmentUrls)
-                .content(content)
+                .content(request.getContent())
                 .views(0)
-                .build();
+                .build());
 
-        return newsEventRepository.save(newsEvent);
+        return new NewsEventDetailResponse(newsEvent);
+    }
+
+    @Transactional
+    public NewsEventDetailResponse updateNewsEvent(Long id, UpdateNewsEventRequest request) throws IOException, URISyntaxException {
+        NewsEventEntity newsEvent = newsEventRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("뉴스이벤트를 찾을 수 없습니다."));
+
+        // S3 업로드 (기존 파일 삭제 후 업로드)
+        if (request.getThumbnail() != null) {
+            s3Uploader.deleteFile(newsEvent.getThumbnailUrl());
+            newsEvent.setThumbnailUrl(s3Uploader.uploadFile(request.getThumbnail(), "newsEvent/" + newsEvent.getUuid() + "/thumbnails"));
+        }
+
+        if (request.getImages() != null) {
+            s3Uploader.deleteFiles(newsEvent.getImageUrls());
+            newsEvent.setImageUrls(s3Uploader.uploadFiles(request.getImages(), "newsEvent/" + newsEvent.getUuid() + "/images"));
+        }
+
+        if (request.getAttachments() != null) {
+            s3Uploader.deleteFiles(newsEvent.getAttachmentUrls());
+            newsEvent.setAttachmentUrls(s3Uploader.uploadFiles(request.getAttachments(), "newsEvent/" + newsEvent.getUuid() + "/attachments"));
+        }
+
+        // 정보 업데이트
+        newsEvent.setTitle(request.getTitle());
+        newsEvent.setCategory(request.getCategory());
+        newsEvent.setContent(request.getContent());
+
+        return new NewsEventDetailResponse(newsEvent);
     }
 
     public void deleteNewsEvent(Long id) {
@@ -77,4 +122,17 @@ public class NewsEventService {
         newsEventRepository.deleteById(id);
     }
 
+    @Transactional
+    public void deleteNewsEvents(List<Long> newsEventIds) {
+        List<NewsEventEntity> newsEvents = newsEventRepository.findAllById(newsEventIds);
+        for (NewsEventEntity newsEvent : newsEvents) {
+            if (newsEvent.getAttachmentUrls() != null) {
+                s3Uploader.deleteFiles(newsEvent.getAttachmentUrls());
+            }
+            if (newsEvent.getImageUrls() != null) {
+                s3Uploader.deleteFiles(newsEvent.getImageUrls());
+            }
+        }
+        newsEventRepository.deleteAllById(newsEventIds);
+    }
 }

--- a/src/main/java/com/hid_web/be/domain/s3/S3Uploader.java
+++ b/src/main/java/com/hid_web/be/domain/s3/S3Uploader.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -136,17 +135,17 @@ public class S3Uploader {
         }
     }
 
-//    // 단일 파일 삭제 (S3)
-//    public void deleteFile(String fileUrl) {
-//        String objectKey = extractObjectKeyFromUrl(fileUrl);
-//
-//        s3Client.deleteObject(
-//                DeleteObjectRequest.builder()
-//                        .bucket(bucketName)
-//                        .key(objectKey)
-//                        .build()
-//        );
-//    }
+    // 단일 파일 삭제 (S3)
+    public void deleteFile(String fileUrl) throws URISyntaxException {
+        String objectKey = extractObjectKeyFromUrl(fileUrl);
+
+        s3Client.deleteObject(
+                DeleteObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(objectKey)
+                        .build()
+        );
+    }
 
     // 다중 파일 삭제
     public void deleteFiles(List<String> fileUrls) {


### PR DESCRIPTION
# Description
뉴스이벤트 도메인의 생성, 수정, 삭제 API를 구현한다.

# Todo
뉴스이벤트 생성, 수정, 삭제 API 구현

- 제목, 대표이미지, 내용, 카테고리, 이미지, 첨부파일을 포함하여 뉴스이벤트 작성

응답 데이터 최적화

- 불필요한 응답 필드 제거
 
# Future

수정 및 삭제시 S3에 데이터가 그대로 남아있는 문제 수정

closes #55 