### PR TITLE
메인 배너 영상 조회 기능 추가 (#57)

### DIFF
--- a/src/main/java/com/hid_web/be/InitDB.java
+++ b/src/main/java/com/hid_web/be/InitDB.java
@@ -1,13 +1,12 @@
 package com.hid_web.be;
 
-import com.hid_web.be.storage.exhibit.ExhibitEntity;
-import com.hid_web.be.storage.exhibit.ExhibitArtistEntity;
+import com.hid_web.be.storage.content.ContentMainVideoEntity;
+import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Component
@@ -15,10 +14,9 @@ import java.util.List;
 public class InitDB {
     private final InitService initService;
 
-//    @PostConstruct
+    @PostConstruct
     public void init() {
-        initService.dbInit1();
-        initService.dbInit2();
+        initService.dbInit();
     }
 
     @Component
@@ -28,60 +26,34 @@ public class InitDB {
 
         private final EntityManager em;
 
-        public void dbInit1() {
-            ExhibitEntity exhibitEntity = new ExhibitEntity();
-            List<ExhibitArtistEntity> exhibitArtistEntities = new ArrayList<>();
+        public void dbInit() {
+            Long year2024 = 2024L;
+            List<ContentMainVideoEntity> existingVideos2024 = em.createQuery(
+                            "SELECT v FROM ContentMainVideoEntity v WHERE v.year = :year", ContentMainVideoEntity.class)
+                    .setParameter("year", year2024)
+                    .getResultList();
 
-            exhibitEntity.setMainImgUrl("대표 이미지");
+            if (existingVideos2024.isEmpty()) {
+                ContentMainVideoEntity contentMainVideoEntity2024 = new ContentMainVideoEntity();
+                contentMainVideoEntity2024.setTitle("2024 졸업 전시 영상");
+                contentMainVideoEntity2024.setS3ObjectKey("graduation-videos/2024/2024_graduation_video.mp4");
+                contentMainVideoEntity2024.setYear(year2024);
+                em.persist(contentMainVideoEntity2024);
+            }
 
-            ExhibitArtistEntity exhibitArtistEntityEntityKZ = new ExhibitArtistEntity();
+            Long year2023 = 2023L;
+            List<ContentMainVideoEntity> existingVideos2023 = em.createQuery(
+                            "SELECT v FROM ContentMainVideoEntity v WHERE v.year = :year", ContentMainVideoEntity.class)
+                    .setParameter("year", year2023)
+                    .getResultList();
 
-            exhibitEntity.setArtistEntities(exhibitArtistEntities);
-
-            exhibitEntity.setTitleKo("여름 전시 제목");
-            exhibitEntity.setTitleEn("Summer Exhibit Title");
-            exhibitEntity.setSubTitleKo("여름 전시 부제");
-            exhibitEntity.setSubTitleEn("Summer Exhibit Subtitle");
-            exhibitEntity.setTextKo("홍익대학교 산업디자인학과 2024 여름 전시 - 1");
-            exhibitEntity.setTextEn("HID Design 2024 Summer Exhibit - 1");
-            exhibitEntity.setVideoUrl("전시 영상 - 1");
-
-            exhibitArtistEntityEntityKZ.setNameEn("Designer A");
-            exhibitArtistEntities.add(exhibitArtistEntityEntityKZ);
-
-            ExhibitArtistEntity exhibitArtistEntityEntityBM = new ExhibitArtistEntity();
-            exhibitArtistEntityEntityBM.setNameEn("Designer B");
-            exhibitArtistEntities.add(exhibitArtistEntityEntityBM);
-
-            em.persist(exhibitEntity);
+            if (existingVideos2023.isEmpty()) {
+                ContentMainVideoEntity contentMainVideoEntity2023 = new ContentMainVideoEntity();
+                contentMainVideoEntity2023.setTitle("2023 졸업 전시 영상");
+                contentMainVideoEntity2023.setS3ObjectKey("graduation-videos/2023/2023_graduation_video.mp4");
+                contentMainVideoEntity2023.setYear(year2023);
+                em.persist(contentMainVideoEntity2023);
+            }
         }
-
-        public void dbInit2() {
-            ExhibitEntity exhibitEntity = new ExhibitEntity();
-            List<ExhibitArtistEntity> exhibitArtistEntities = new ArrayList<>();
-
-            exhibitEntity.setArtistEntities(exhibitArtistEntities);
-
-            exhibitEntity.setTitleKo("여름 전시 제목");
-            exhibitEntity.setTitleEn("Summer Exhibit Title");
-            exhibitEntity.setSubTitleKo("여름 전시 부제");
-            exhibitEntity.setSubTitleEn("Summer Exhibit Subtitle");
-            exhibitEntity.setTextKo("홍익대학교 산업디자인학과 2024 여름 전시 - 2");
-            exhibitEntity.setTextEn("HID Design 2024 Summer Exhibit - 2");
-            exhibitEntity.setVideoUrl("전시 영상 - 2");
-
-            exhibitEntity.setMainImgUrl("대표 이미지");
-
-            ExhibitArtistEntity exhibitArtistEntityEntityJS = new ExhibitArtistEntity();
-            exhibitArtistEntityEntityJS.setNameEn("Designer C");
-            exhibitArtistEntities.add(exhibitArtistEntityEntityJS);
-
-            ExhibitArtistEntity exhibitArtistEntityEntityYY = new ExhibitArtistEntity();
-            exhibitArtistEntityEntityYY.setNameEn("Designer D");
-            exhibitArtistEntities.add(exhibitArtistEntityEntityYY);
-
-            em.persist(exhibitEntity);
-        }
-
     }
 }

--- a/src/main/java/com/hid_web/be/controller/content/ContentController.java
+++ b/src/main/java/com/hid_web/be/controller/content/ContentController.java
@@ -1,0 +1,24 @@
+package com.hid_web.be.controller.content;
+
+import com.hid_web.be.controller.content.response.ContentMainVideoResponse;
+import com.hid_web.be.domain.content.ContentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/contents")
+public class ContentController {
+
+    private final ContentService contentService;
+
+    @GetMapping("/main-video/{exhibitYear}")
+    public ResponseEntity<ContentMainVideoResponse> findMainVideoByYear(@PathVariable("exhibitYear") Long year) {
+        ContentMainVideoResponse video = contentService.findMainVideoByYear(year);
+        return ResponseEntity.ok(video);
+    }
+}

--- a/src/main/java/com/hid_web/be/controller/content/response/ContentMainVideoResponse.java
+++ b/src/main/java/com/hid_web/be/controller/content/response/ContentMainVideoResponse.java
@@ -1,0 +1,21 @@
+package com.hid_web.be.controller.content.response;
+
+import com.hid_web.be.domain.s3.S3UrlConverter;
+import com.hid_web.be.storage.content.ContentMainVideoEntity;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA, Jackson 라이브러리에서 기본 생성자 필요
+@AllArgsConstructor(access = AccessLevel.PROTECTED) // 빌더 패턴에서 필요
+public class ContentMainVideoResponse {
+    private Long year;
+    private String videoUrl;
+
+    public static ContentMainVideoResponse of(ContentMainVideoEntity contentMainVideoEntity) {
+        return ContentMainVideoResponse.builder()
+                .year(contentMainVideoEntity.getYear())
+                .videoUrl(S3UrlConverter.convertCloudfrontUrlFromObjectKey(contentMainVideoEntity.getS3ObjectKey()))
+                .build();
+    }
+}

--- a/src/main/java/com/hid_web/be/domain/content/ContentMainVideo.java
+++ b/src/main/java/com/hid_web/be/domain/content/ContentMainVideo.java
@@ -1,0 +1,15 @@
+package com.hid_web.be.domain.content;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ContentMainVideo {
+    private Long id;
+    private String title;
+    private String s3ObjectKey;
+    private int year;
+}

--- a/src/main/java/com/hid_web/be/domain/content/ContentService.java
+++ b/src/main/java/com/hid_web/be/domain/content/ContentService.java
@@ -1,0 +1,20 @@
+package com.hid_web.be.domain.content;
+
+import com.hid_web.be.controller.content.response.ContentMainVideoResponse;
+import com.hid_web.be.storage.content.ContentMainVideoEntity;
+import com.hid_web.be.storage.content.ContentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ContentService {
+
+    private final ContentRepository contentRepository;
+
+    public ContentMainVideoResponse findMainVideoByYear(Long year) {
+        ContentMainVideoEntity contentMainVideoEntity = contentRepository.findByYear(year);
+
+        return ContentMainVideoResponse.of(contentMainVideoEntity);
+    }
+}

--- a/src/main/java/com/hid_web/be/domain/s3/S3UrlConverter.java
+++ b/src/main/java/com/hid_web/be/domain/s3/S3UrlConverter.java
@@ -1,0 +1,26 @@
+package com.hid_web.be.domain.s3;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class S3UrlConverter {
+    public static String convertObjectKeyFromUrl(String url) {
+        // CloudFront URL과 S3 URL 모두 처리
+        int comIndex = url.indexOf(".com");
+        int netIndex = url.indexOf(".net");
+
+        if (comIndex != -1) {
+            return url.substring(comIndex + 5);
+        } else if (netIndex != -1) {
+            return url.substring(netIndex + 5);
+        } else {
+            throw new IllegalArgumentException("URL 형식이 S3 또는 CloudFront 형식이 아닙니다: " + url);
+        }
+    }
+
+    public static String convertCloudfrontUrlFromObjectKey(String objectKey) {
+        String CLOUDFRONT_DEV_DOMAIN= "df4nh3dlx8zzx.cloudfront.net";
+        String CLOUDFRONT_PRD_DOMAIN = "di00vgoc2ngki.cloudfront.net";
+        return "https://" + CLOUDFRONT_PRD_DOMAIN + "/" + objectKey;
+    }
+}

--- a/src/main/java/com/hid_web/be/storage/content/ContentMainVideoEntity.java
+++ b/src/main/java/com/hid_web/be/storage/content/ContentMainVideoEntity.java
@@ -1,0 +1,21 @@
+package com.hid_web.be.storage.content;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+public class ContentMainVideoEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String s3ObjectKey;
+    private Long year;
+}

--- a/src/main/java/com/hid_web/be/storage/content/ContentRepository.java
+++ b/src/main/java/com/hid_web/be/storage/content/ContentRepository.java
@@ -1,0 +1,9 @@
+package com.hid_web.be.storage.content;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContentRepository extends JpaRepository<ContentMainVideoEntity, Long> {
+     ContentMainVideoEntity findByYear(Long year);
+}


### PR DESCRIPTION
### Description
매년 대표 전시 영상이 새로 생성되며, 용량이 크므로 리소스에 대해 효율적으로 제공해야 한다.

### Todo
S3 및 CloudFront를 이용한 영상 서빙 인프라 추가
메인 배너 영상 조회 기능 추가

### Future
관리자 페이지에서 영상을 관리할 수 있도록 추가 구현이 필요하다.