### PR TITLE
요청 데이터에 대한 검증 수행 및 적절한 예외 처리 기능 구현 (#61)

### DIFF
--- a/src/main/java/com/hid_web/be/controller/ExhibitApiControllerAdvice.java
+++ b/src/main/java/com/hid_web/be/controller/ExhibitApiControllerAdvice.java
@@ -1,0 +1,46 @@
+package com.hid_web.be.controller;
+
+import com.hid_web.be.support.error.ErrorCode;
+import com.hid_web.be.support.error.ErrorResponse;
+import com.hid_web.be.support.error.ExhibitException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExhibitApiControllerAdvice {
+    /**
+     *  javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다.
+     *  HttpMessageConverter 에서 등록한 HttpMessageConverter binding 못할경우 발생
+     *  주로 @RequestBody, @RequestPart 어노테이션에서 발생
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidException(MethodArgumentNotValidException e) {
+        ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+        BindingResult bindingResult = e.getBindingResult(); // MethodArgumentNotValidException의 부모인 BindException이 BindingResult를 가진다.
+
+        StringBuilder builder = new StringBuilder();
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            builder.append("[");
+            builder.append(fieldError.getField());
+            builder.append("](은)는 ");
+            builder.append(fieldError.getDefaultMessage());
+            builder.append(". ");
+        }
+        builder.deleteCharAt(builder.length() - 1);
+
+        final ErrorResponse response = ErrorResponse.of(errorCode, builder.toString());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ExhibitException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(final ExhibitException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode, e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/hid_web/be/support/error/ErrorCode.java
+++ b/src/main/java/com/hid_web/be/support/error/ErrorCode.java
@@ -1,0 +1,35 @@
+package com.hid_web.be.support.error;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT_VALUE(400, "COMMON-001", "유효성 검증에 실패한 경우"),
+    INTERNAL_SERVER_ERROR(500, "COMMON-002", "서버에서 처리할 수 없는 경우"),
+
+    // Exhibit
+    /**
+     * 전시가 존재하지 않을 경우
+     */
+    EXHIBIT_NOT_FOUND(404, "EXHIBIT-001", "전시를 찾을 수 없는 경우"),
+    /**
+     * Admin 권한 확인
+     */
+    EXHIBIT_ACCESS_DENIED(403, "EXHIBIT-003", "전시에 대한 권한이 없는 경우"),
+    /**
+     * 외부 API인 S3 관련 트랜잭션 오류 시 전시 불가능 상태인 Fail로 변경
+     */
+    EXHIBIT_INVALID_STATUS(400, "EXHIBIT-004", "잘못된 전시 상태인 경우");
+
+    private final int status;
+    private final String code;
+    private final String description;
+
+    ErrorCode(int status, String code, String description) {
+        this.status = status;
+        this.code = code;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/hid_web/be/support/error/ErrorResponse.java
+++ b/src/main/java/com/hid_web/be/support/error/ErrorResponse.java
@@ -1,0 +1,22 @@
+package com.hid_web.be.support.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Domain 계층에서 HTTP status code에 의존하지 않도록 하여 역방향 참조를 막는다.
+ */
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private final String code;
+    private final String message;
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return new ErrorResponse(errorCode.getCode(), message);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getDescription());
+    }
+}

--- a/src/main/java/com/hid_web/be/support/error/ExhibitException.java
+++ b/src/main/java/com/hid_web/be/support/error/ExhibitException.java
@@ -1,0 +1,15 @@
+package com.hid_web.be.support.error;
+
+public class ExhibitException extends RuntimeException {
+    private ErrorCode errorCode;
+    private String message;
+
+    public ExhibitException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}


### PR DESCRIPTION
### Description
많은 전시 수합물에 대해 수합 가이드라인을 준수하여야 일관성있게 관리할 수 있다.
전시 데이터는 글자 수 제한, 파일 크기 업로드 제한, 링크 형식 제한 등 다양한 검증을 수행한 후 실패 시 적절한 예외를 응답해야한다.

### Todo
필드에 대한 검증 수행 시 @Valid 또는 @Validate를 많이 사용하는데 이때 바인딩 에러 시 MethodArgumentNotValidException가 발생하며 내부적으로 등록된 HttpMessageConverter가 바인딩하지 못할 시 발생되므로 이에 대해 예외 처리를 해야한다.
Enum 클래스을 이용해 HTTP 상태 코드, 커스텀 예외 코드, 예외 메시지를 관리할 수 있도록 한다.
에러 응답 DTO를 이용해 Domain 계층에서 HTTP status code에 의존하지 않도록 하여 역방향 참조를 막아 일관된 응답을 할 수 있도록 한다.

### Future
일관성이 가장 중요하므로 상세한 예외 처리를 추가해나가야한다.