### PR TITLE
전시 제목 및 학생 이름에 대한 국문 또는 영문 부분 일치 검색 기능 구현 (#63)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,9 +33,11 @@ dependencies {
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3' // S3 연동
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store' // Parameter Store 연동
 	implementation 'org.springframework.boot:spring-boot-starter-validation' // 유효성 검사
-	implementation 'commons-io:commons-io:2.11.0'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5' // JWT
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5' // JWT
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JWT
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/hid_web/be/controller/exhibit/ExhibitApiControllerAdvice.java
+++ b/src/main/java/com/hid_web/be/controller/exhibit/ExhibitApiControllerAdvice.java
@@ -1,4 +1,4 @@
-package com.hid_web.be.controller;
+package com.hid_web.be.controller.exhibit;
 
 import com.hid_web.be.support.error.ErrorCode;
 import com.hid_web.be.support.error.ErrorResponse;

--- a/src/main/java/com/hid_web/be/controller/exhibit/ExhibitController.java
+++ b/src/main/java/com/hid_web/be/controller/exhibit/ExhibitController.java
@@ -4,6 +4,8 @@ import com.hid_web.be.controller.exhibit.request.CreateExhibitRequest;
 import com.hid_web.be.controller.exhibit.request.UpdateExhibitRequest;
 import com.hid_web.be.controller.exhibit.response.ExhibitPreviewResponse;
 import com.hid_web.be.controller.exhibit.response.ExhibitResponse;
+import com.hid_web.be.domain.exhibit.ExhibitType;
+import com.hid_web.be.domain.exhibit.SearchType;
 import com.hid_web.be.storage.exhibit.ExhibitEntity;
 import com.hid_web.be.domain.exhibit.ExhibitService;
 import lombok.AllArgsConstructor;
@@ -80,6 +82,24 @@ public class ExhibitController {
         } catch (IOException e) {
             return ResponseEntity.internalServerError().build();
         }
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<ExhibitPreviewResponse>> searchExhibits(
+            @RequestParam ExhibitType exhibitType,
+            @RequestParam String year,
+            @RequestParam SearchType searchType,
+            @RequestParam String searchTerm
+    ) {
+        List<ExhibitEntity> results = exhibitService.searchExhibits(
+                searchTerm, exhibitType, year, searchType
+        );
+
+        List<ExhibitPreviewResponse> previews = results.stream()
+                .map(ExhibitPreviewResponse::of)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(previews);
     }
 
     @Data

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitReader.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitReader.java
@@ -18,4 +18,12 @@ public class ExhibitReader {
     public ExhibitEntity findExhibitById(Long exhibitId) {
         return exhibitRepository.findExhibitByExhibitId(exhibitId);
     }
+
+    public List<ExhibitEntity> searchByArtistName(String searchTerm, ExhibitType type, String year) {
+        return exhibitRepository.searchByArtistName(searchTerm, type, year);
+    }
+
+    public List<ExhibitEntity> searchByTitle(String searchTerm, ExhibitType type, String year) {
+        return exhibitRepository.searchByTitle(searchTerm, type, year);
+    }
 }

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitService.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitService.java
@@ -222,7 +222,7 @@ public class ExhibitService {
         // 전시 상세 텍스트 Update
         if (details != null) {
             if (details.getExhibitType() != null) {
-                exhibitEntity.setExhibitType(details.getExhibitType());
+                exhibitEntity.setType(details.getExhibitType());
             }
             if (details.getYear() != null) {
                 exhibitEntity.setYear(details.getYear());
@@ -352,6 +352,22 @@ public class ExhibitService {
 
         s3Writer.deleteObjects(exhibitEntity.getExhibitUUID());
         exhibitWriter.deleteExhibit(exhibitId);
+    }
+
+    public List<ExhibitEntity> searchExhibits(
+            String searchTerm,
+            ExhibitType exhibitType,
+            String year,
+            SearchType searchType
+    ) {
+        switch (searchType) {
+            case ARTIST:
+                return exhibitReader.searchByArtistName(searchTerm, exhibitType, year);
+            case TITLE:
+                return exhibitReader.searchByTitle(searchTerm, exhibitType, year);
+            default:
+                throw new IllegalArgumentException("유효하지 않은 검색 타입입니다: " + searchType);
+        }
     }
 }
 

--- a/src/main/java/com/hid_web/be/domain/exhibit/SearchType.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/SearchType.java
@@ -1,0 +1,6 @@
+package com.hid_web.be.domain.exhibit;
+
+public enum SearchType {
+    ARTIST(),
+    TITLE();
+}

--- a/src/main/java/com/hid_web/be/storage/exhibit/ExhibitEntity.java
+++ b/src/main/java/com/hid_web/be/storage/exhibit/ExhibitEntity.java
@@ -22,7 +22,7 @@ public class ExhibitEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private ExhibitType exhibitType;
+    private ExhibitType type;
 
     @Column(nullable = false)
     private int year;

--- a/src/main/java/com/hid_web/be/storage/exhibit/ExhibitRepository.java
+++ b/src/main/java/com/hid_web/be/storage/exhibit/ExhibitRepository.java
@@ -1,9 +1,34 @@
 package com.hid_web.be.storage.exhibit;
 
+import com.hid_web.be.domain.exhibit.ExhibitType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 
 public interface ExhibitRepository extends JpaRepository<ExhibitEntity, Long> {
     List<ExhibitEntity> findAll();
     ExhibitEntity findExhibitByExhibitId(Long exhibitId);
+
+    @Query("SELECT DISTINCT e FROM ExhibitEntity e " +
+            "JOIN e.artistEntities a " +
+            "WHERE (LOWER(a.nameKo) LIKE LOWER(CONCAT('%', :searchTerm, '%')) " +
+            "OR LOWER(a.nameEn) LIKE LOWER(CONCAT('%', :searchTerm, '%'))) " +
+            "AND e.type = :type " +
+            "AND e.year = :year")
+    List<ExhibitEntity> searchByArtistName(
+            @Param("searchTerm") String searchTerm,
+            @Param("type") ExhibitType type,
+            @Param("year") String year);
+
+    @Query("SELECT e FROM ExhibitEntity e " +
+            "WHERE (LOWER(e.titleKo) LIKE LOWER(CONCAT('%', :searchTerm, '%')) " +
+            "OR LOWER(e.titleEn) LIKE LOWER(CONCAT('%', :searchTerm, '%'))) " +
+            "AND e.type = :type " +
+            "AND e.year = :year")
+    List<ExhibitEntity> searchByTitle(
+            @Param("searchTerm") String searchTerm,
+            @Param("type") ExhibitType type,
+            @Param("year") String year);
 }


### PR DESCRIPTION
### Description
전시가 많으므로 페이지에 보이지 않는 전시에 대해서도 사용자에게 제공해야한다.

전시를 보러오는 사용자들은 주로 전시 참여 학생 이름 또는 전시 제목을 알고 있을 것이라는 분석을 기반으로 검색 기능을 제공해야 한다.

### Todo
JPQL(Java Persistence Query Language) 쿼리를 이용한다.

검색 기능을 이용하기 전 이미 전시 연도와 전시 타입이 페이지 내에서 결정되어 있으므로 조건을 기반으로 검색 기능을 구현한다.

검색된 제목이 국문과 영문 모두에서 단어가 부분 일치되는 검색된 전시를 제공하는 기능을 구현한다.

검색된 참여 학생 이름이 국문과 영문 모두에서 부분 일치되며 동일한 전시가 다중 검색될 가능성이 있으므로 중복을 제거하여 검색된 전시를 제공하는 기능을 구현한다.

### Future
엘라스틱서치 등 오픈소스 검색 엔진을 도입하여 대량의 전시 데이터에서 더 효율적인 검색 인덱싱을 통해 시스템 성능을 최적화하고, 검색 품질을 향상시키는 다양한 기능을 제공하여 사용자 경험을 개선하면 좋을 것이다.