### PR TITLE
전시 프리뷰 필터링 조회 기능 구현 (#65)

### DIFF
--- a/src/main/java/com/hid_web/be/controller/exhibit/ExhibitController.java
+++ b/src/main/java/com/hid_web/be/controller/exhibit/ExhibitController.java
@@ -24,14 +24,17 @@ public class ExhibitController {
     private final ExhibitService exhibitService;
 
     @GetMapping("/previews")
-    public ResponseEntity<Result<List<ExhibitPreviewResponse>>> findAllExhibitPreview() {
-        List<ExhibitEntity> exhibitEntityList = exhibitService.findAllExhibit();
-        List<ExhibitPreviewResponse> exhibitPreviewResponseList = exhibitEntityList.stream()
-                .map(e -> ExhibitPreviewResponse.of(e))
+    public ResponseEntity<Result<List<ExhibitPreviewResponse>>> findExhibitPreviewsByTypeYearAndTerm(
+            @RequestParam ExhibitType exhibitType,
+            @RequestParam(defaultValue = "2024") String year,
+            @RequestParam(defaultValue = "ALL") String term) {
+        List<ExhibitEntity> exhibitEntities = exhibitService.findExhibitsByTypeYearAndTerm(exhibitType, year, term);
+
+        List<ExhibitPreviewResponse> exhibitPreviewResponses = exhibitEntities.stream()
+                .map(ExhibitPreviewResponse::of)
                 .collect(Collectors.toList());
 
-        // Result 객체로 리스트를 감싸서 반환
-        return ResponseEntity.ok().body(new Result<>(exhibitPreviewResponseList));
+        return ResponseEntity.ok().body(new Result<>(exhibitPreviewResponses));
     }
 
     @GetMapping("/{exhibitId}")

--- a/src/main/java/com/hid_web/be/controller/exhibit/response/ExhibitResponse.java
+++ b/src/main/java/com/hid_web/be/controller/exhibit/response/ExhibitResponse.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class ExhibitResponse {
     private Long exhibitId;
     private ExhibitType exhibitType;
-    private Integer year;
+    private String year;
     private String major;
     private String club;
     private String mainImgUrl;
@@ -32,7 +32,7 @@ public class ExhibitResponse {
     public static ExhibitResponse of(ExhibitEntity exhibitEntity) {
         return ExhibitResponse.builder()
                 .exhibitId(exhibitEntity.getExhibitId())
-                .exhibitType(exhibitEntity.getExhibitType())
+                .exhibitType(exhibitEntity.getType())
                 .year(exhibitEntity.getYear())
                 .major(exhibitEntity.getMajor())
                 .club(exhibitEntity.getClub())

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitReader.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitReader.java
@@ -11,8 +11,16 @@ import java.util.List;
 public class ExhibitReader {
     private final ExhibitRepository exhibitRepository;
 
-    public List<ExhibitEntity> findAllExhibit() {
-        return exhibitRepository.findAll();
+    public List<ExhibitEntity> findByTypeAndYear(ExhibitType type, String year) {
+        return exhibitRepository.findByTypeAndYear(type, year);
+    }
+
+    public List<ExhibitEntity> findByTypeAndYearAndClub(ExhibitType exhibitType, String year, String club) {
+        return exhibitRepository.findByTypeAndYearAndClub(exhibitType, year, club);
+    }
+
+    public List<ExhibitEntity> findByTypeAndYearAndMajor(ExhibitType type, String year, String major) {
+        return exhibitRepository.findByTypeAndYearAndMajor(type, year, major);
     }
 
     public ExhibitEntity findExhibitById(Long exhibitId) {

--- a/src/main/java/com/hid_web/be/domain/exhibit/ExhibitService.java
+++ b/src/main/java/com/hid_web/be/domain/exhibit/ExhibitService.java
@@ -23,8 +23,16 @@ public class ExhibitService {
     private final ExhibitReader exhibitReader;
     private final ExhibitExtractor exhibitExtractor;
 
-    public List<ExhibitEntity> findAllExhibit() {
-        return exhibitReader.findAllExhibit();
+    public List<ExhibitEntity> findExhibitsByTypeYearAndTerm(ExhibitType exhibitType, String year, String term) {
+        if ("ALL".equals(term)) {
+            return exhibitReader.findByTypeAndYear(exhibitType, year);
+        }
+
+        if (exhibitType == ExhibitType.CLUB) {
+            return exhibitReader.findByTypeAndYearAndClub(exhibitType, year, term);
+        } else {
+            return exhibitReader.findByTypeAndYearAndMajor(exhibitType, year, term);
+        }
     }
 
     public ExhibitEntity findExhibitByExhibitId(Long exhibitId) {

--- a/src/main/java/com/hid_web/be/storage/exhibit/ExhibitEntity.java
+++ b/src/main/java/com/hid_web/be/storage/exhibit/ExhibitEntity.java
@@ -25,7 +25,7 @@ public class ExhibitEntity {
     private ExhibitType type;
 
     @Column(nullable = false)
-    private int year;
+    private String year;
 
     private String major;
 

--- a/src/main/java/com/hid_web/be/storage/exhibit/ExhibitRepository.java
+++ b/src/main/java/com/hid_web/be/storage/exhibit/ExhibitRepository.java
@@ -9,6 +9,13 @@ import java.util.List;
 
 public interface ExhibitRepository extends JpaRepository<ExhibitEntity, Long> {
     List<ExhibitEntity> findAll();
+
+    List<ExhibitEntity> findByTypeAndYear(ExhibitType exhibitType, String year);
+
+    List<ExhibitEntity> findByTypeAndYearAndClub(ExhibitType exhibitType, String year, String club);
+
+    List<ExhibitEntity> findByTypeAndYearAndMajor(ExhibitType exhibitType, String year, String major);
+
     ExhibitEntity findExhibitByExhibitId(Long exhibitId);
 
     @Query("SELECT DISTINCT e FROM ExhibitEntity e " +


### PR DESCRIPTION
### Description
졸업 전시와 소모임 전시로 전시에 대한 유형으로 대분류 카테고리가 존재한다.

그 안에서 연도로 중분류 카테고리가 존재하며 졸업 전시라면 전공명으로, 소모임 전시라면 소모임명으로 소분류 카테고리가 존재한다.

전시라는 도메인 특성에 따라 최소 중분류 카테고리까지는 사용자가 필요로 할것이고 소분류 카테고리도 일부 사용자에 의해 필요로 할 것이다.

### Todo
중분류까진 필수로 소분류는 선택으로 소분류 카테고리까지 전시 필터링을 하여 프리뷰 목록을 제공하는 기능을 구현한다.

### Future
필터링은 대부분의 사용자에 의해 적용되므로 캐싱을 도입하면 최적화할 수 있을 것이다.