### PR TITLE
S3 첨부파일 저장 및 뉴스이벤트 썸네일 삭제 누락 문제 수정 (#69)

### DIFF
--- a/src/main/java/com/hid_web/be/InitCommunityDB.java
+++ b/src/main/java/com/hid_web/be/InitCommunityDB.java
@@ -20,9 +20,9 @@ public class InitCommunityDB {
     private final InitService initService;
 
     //@PostConstruct
-    public void init() {
-        initService.dbInit();
-    }
+//    public void init() {
+//        initService.dbInit();
+//    }
 
     @Component
     @Transactional
@@ -31,34 +31,34 @@ public class InitCommunityDB {
 
         private final EntityManager em;
 
-        public void dbInit() {
-
-            NoticeEntity notice = NoticeEntity.builder()
-                    .uuid("notice-uuid-123")
-                    .title("공지사항 예제")
-                    .author(NoticeAuthorType.valueOf("TA"))
-                    .createdDate(LocalDate.now())
-                    .content("공지사항 본문 내용입니다.")
-                    .views(0)
-                    .isImportant(true)
-                    .attachmentUrls(List.of("https://s3-bucket-url/notice/attachments/sample.pdf"))
-                    .imageUrls(List.of("https://s3-bucket-url/notice/images/sample.jpg"))
-                    .build();
-            em.persist(notice);
-
-            NewsEventEntity newsEvent = NewsEventEntity.builder()
-                    .uuid("newsEvent-uuid-456")
-                    .title("뉴스이벤트 예제")
-                    .category(NewsEventCategory.AWARD)
-                    .createdDate(LocalDate.now())
-                    .content("뉴스이벤트 본문 내용입니다.")
-                    .views(0)
-                    .thumbnailUrl("https://s3-bucket-url/newsEvent/thumbnails/sample-thumbnail.jpg")
-                    .attachmentUrls(List.of("https://s3-bucket-url/newsEvent/attachments/sample-file.pdf"))
-                    .imageUrls(List.of("https://s3-bucket-url/newsEvent/images/sample1.jpg"))
-                    .build();
-            em.persist(newsEvent);
-
-        }
+//        public void dbInit() {
+//
+//            NoticeEntity notice = NoticeEntity.builder()
+//                    .uuid("notice-uuid-123")
+//                    .title("공지사항 예제")
+//                    .author(NoticeAuthorType.valueOf("TA"))
+//                    .createdDate(LocalDate.now())
+//                    .content("공지사항 본문 내용입니다.")
+//                    .views(0)
+//                    .isImportant(true)
+//                    .attachmentUrls(List.of("https://s3-bucket-url/notice/attachments/sample.pdf"))
+//                    .imageUrls(List.of("https://s3-bucket-url/notice/images/sample.jpg"))
+//                    .build();
+//            em.persist(notice);
+//
+//            NewsEventEntity newsEvent = NewsEventEntity.builder()
+//                    .uuid("newsEvent-uuid-456")
+//                    .title("뉴스이벤트 예제")
+//                    .category(NewsEventCategory.AWARD)
+//                    .createdDate(LocalDate.now())
+//                    .content("뉴스이벤트 본문 내용입니다.")
+//                    .views(0)
+//                    .thumbnailUrl("https://s3-bucket-url/newsEvent/thumbnails/sample-thumbnail.jpg")
+//                    .attachmentUrls(List.of("https://s3-bucket-url/newsEvent/attachments/sample-file.pdf"))
+//                    .imageUrls(List.of("https://s3-bucket-url/newsEvent/images/sample1.jpg"))
+//                    .build();
+//            em.persist(newsEvent);
+//
+//        }
     }
 }

--- a/src/main/java/com/hid_web/be/controller/community/NoticeController.java
+++ b/src/main/java/com/hid_web/be/controller/community/NoticeController.java
@@ -6,7 +6,6 @@ import com.hid_web.be.controller.community.response.CustomPageResponse;
 import com.hid_web.be.controller.community.response.NoticeDetailResponse;
 import com.hid_web.be.controller.community.response.NoticeResponse;
 import com.hid_web.be.domain.community.NoticeService;
-import com.hid_web.be.storage.community.NoticeEntity;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -15,9 +14,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/notices")
@@ -40,19 +41,19 @@ public class NoticeController {
         return ResponseEntity.ok(noticeService.getNoticeDetail(noticeId));
     }
 
-    // 공지사항 첨부파일 ZIP 다운로드 API 추가
-    @GetMapping("/{noticeId}/download-attachments")
-    public ResponseEntity<byte[]> downloadAttachments(@PathVariable Long noticeId) throws IOException, URISyntaxException {
-        return noticeService.downloadAllAttachmentsAsZip(noticeId);
+    // 공지사항 첨부파일 개별 다운로드 API 추가
+    @GetMapping("/{noticeId}/attachment-urls")
+    public ResponseEntity<Map<String, String>> getAttachmentUrls(@PathVariable Long noticeId) throws FileNotFoundException, URISyntaxException {
+        return noticeService.getAllAttachmentUrls(noticeId);
     }
 
     @PostMapping
-    public ResponseEntity<NoticeEntity> createNotice(@Valid @ModelAttribute CreateNoticeRequest request) throws IOException {
+    public ResponseEntity<NoticeDetailResponse> createNotice(@Valid @ModelAttribute CreateNoticeRequest request) throws IOException {
         return ResponseEntity.ok(noticeService.createNotice(request));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<NoticeEntity> updateNotice(
+    public ResponseEntity<NoticeDetailResponse> updateNotice(
             @PathVariable Long id,
             @Valid @ModelAttribute UpdateNoticeRequest request
     ) throws IOException {

--- a/src/main/java/com/hid_web/be/domain/s3/S3Uploader.java
+++ b/src/main/java/com/hid_web/be/domain/s3/S3Uploader.java
@@ -1,32 +1,18 @@
 package com.hid_web.be.domain.s3;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.*;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
-import java.nio.charset.Charset;
+import java.net.*;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -36,18 +22,17 @@ public class S3Uploader {
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
 
+    @Value("${cloudfront.domain}")  // CloudFront 도메인 환경변수로 설정
+    private String cloudFrontDomain;
+
     // 단일 파일 업로드 (빈 파일 검증 추가)
     public String uploadFile(MultipartFile file, String folderPath) throws IOException {
-        if (file == null || file.isEmpty()) {  // 빈 파일이면 업로드하지 않음
+        if (file == null || file.isEmpty()) {
             return null;
         }
 
-        // 파일명 안전하게 인코딩 (공백 처리 포함)
-        String encodedOriginalFileName = URLEncoder.encode(file.getOriginalFilename(), StandardCharsets.UTF_8)
-                .replaceAll("\\+", "%20");
-
-        String randomFileName = UUID.randomUUID().toString();
-        String objectKey = folderPath + "/" + randomFileName + "_" + encodedOriginalFileName;
+        String originalFileName = sanitizeFileName(file.getOriginalFilename());
+        String objectKey = folderPath + "/" + originalFileName;
 
         // S3 업로드
         s3Client.putObject(
@@ -59,84 +44,23 @@ public class S3Uploader {
                 RequestBody.fromBytes(file.getBytes())
         );
 
-        // 업로드된 파일 URL 반환
-        return "https://" + bucketName + ".s3.amazonaws.com/" + objectKey;
+        return objectKey;
     }
 
-    // 다중 파일 업로드 (빈 파일 검증 추가)
-    public List<String> uploadFiles(List<MultipartFile> files, String folderPath) throws IOException {
-        List<String> urls = new ArrayList<>();
-        if (files != null && !files.isEmpty()) {
-            for (MultipartFile file : files) {
-                if (!file.isEmpty()) {  // 빈 파일이면 건너뜀
-                    urls.add(uploadFile(file, folderPath));
-                }
+    public Map<String, String> uploadFiles(List<MultipartFile> files, String folderPath) throws IOException {
+        Map<String, String> fileMap = new HashMap<>();
+
+        for (MultipartFile file : files) {
+            if (!file.isEmpty()) {
+                String objectKey = uploadFile(file, folderPath);
+                fileMap.put(objectKey, file.getOriginalFilename());
             }
         }
-        return urls;
-    }
-
-    // S3 업로드 로직
-    private String uploadToS3(MultipartFile file, String folderPath) throws IOException {
-        // 파일명 인코딩 및 공백 처리
-        String encodedFileName = URLEncoder.encode(file.getOriginalFilename(), StandardCharsets.UTF_8.toString())
-                .replaceAll("\\+", "%20"); // 공백을 %20으로 변환
-
-        // 무작위 UUID로 안전한 파일명 생성 (보안 강화)
-        String randomFileName = UUID.randomUUID().toString();
-
-        // S3에 저장될 object key 생성
-        String objectKey = folderPath + "/" + randomFileName;
-
-        // S3에 파일 업로드
-        s3Client.putObject(
-                PutObjectRequest.builder()
-                        .bucket(bucketName)
-                        .key(objectKey)
-                        .contentType(file.getContentType()) // 파일 형식 설정
-                        .build(),
-                RequestBody.fromBytes(file.getBytes())
-        );
-
-        // 업로드된 파일 URL 반환
-        return "https://" + bucketName + ".s3.amazonaws.com/" + objectKey;
-    }
-
-    // 여러 개의 S3 파일을 ZIP으로 묶어 다운로드
-    public byte[] downloadAllAsZip(List<String> fileUrls) throws IOException, URISyntaxException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-
-        // 한글 파일명을 위한 UTF-8 인코딩 설정
-        try (ZipOutputStream zipOutputStream = new ZipOutputStream(byteArrayOutputStream, Charset.forName("UTF-8"))) {
-            for (String fileUrl : fileUrls) {
-                String originalFileName = extractOriginalFileNameFromUrl(fileUrl);
-                byte[] fileData = downloadFileFromS3(fileUrl);
-
-                ZipEntry zipEntry = new ZipEntry(originalFileName);
-                zipOutputStream.putNextEntry(zipEntry);
-                zipOutputStream.write(fileData);
-                zipOutputStream.closeEntry();
-            }
-        }
-        return byteArrayOutputStream.toByteArray();
-    }
-
-    // S3에서 개별 파일 다운로드
-    private byte[] downloadFileFromS3(String fileUrl) throws IOException, URISyntaxException {
-        String objectKey = extractObjectKeyFromUrl(fileUrl);
-
-        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
-                .bucket(bucketName)
-                .key(objectKey)
-                .build();
-
-        try (ResponseInputStream<GetObjectResponse> s3Object = s3Client.getObject(getObjectRequest)) {
-            return IOUtils.toByteArray(s3Object); // 파일 데이터 읽기
-        }
+        return fileMap;
     }
 
     // 단일 파일 삭제 (S3)
-    public void deleteFile(String fileUrl) throws URISyntaxException {
+    public void deleteFile(String fileUrl) {
         String objectKey = extractObjectKeyFromUrl(fileUrl);
 
         s3Client.deleteObject(
@@ -160,55 +84,29 @@ public class S3Uploader {
         }
     }
 
-//    // S3 URL에서 Object Key 추출
-//    private String extractObjectKeyFromUrl(String fileUrl) {
-//        try {
-//            URI uri = new URI(fileUrl);
-//            return uri.getPath().substring(1); // 앞의 '/' 제거
-//        } catch (URISyntaxException e) {
-//            throw new IllegalArgumentException("잘못된 파일 URL 형식입니다: " + fileUrl, e);
-//        }
-//    }
-
-    private String extractObjectKeyFromUrl(String fileUrl) throws URISyntaxException {
-        URI uri = new URI(fileUrl);
-        String path = uri.getPath(); // 예: "/notice/uuid/attachments/파일명"
-
-        // 첫 번째 "/" 제거 후 반환
-        return path.startsWith("/") ? path.substring(1) : path;
-    }
-
-
-    private String extractFileNameFromUrl(String fileUrl) {
+    private String extractObjectKeyFromUrl(String fileUrl) {
         try {
-            // URL에서 파일명 부분만 추출
-            URI uri = new URI(fileUrl);
-            String path = uri.getPath(); // "/bucket-name/folder/filename.ext"
+            // 직접 URI를 만들지 않고, S3 URL에서 Key 부분만 안전하게 추출
+            String objectKey = fileUrl.replace("https://" + bucketName + ".s3.amazonaws.com/", "");
 
-            return path.substring(path.lastIndexOf("/") + 1);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("잘못된 파일 URL 형식입니다: " + fileUrl, e);
-        }
-    }
-
-    private String extractOriginalFileNameFromUrl(String fileUrl) {
-        String encodedFileName = fileUrl.substring(fileUrl.lastIndexOf("_") + 1);
-        try {
-            return URLDecoder.decode(encodedFileName, StandardCharsets.UTF_8.toString());
+            // URL 디코딩 적용 (공백 등 변환)
+            return URLDecoder.decode(objectKey, StandardCharsets.UTF_8.toString());
         } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException("파일명 디코딩 오류", e);
+            throw new RuntimeException("파일 경로 디코딩 오류", e);
         }
     }
 
-    // 한글 파일명을 올바르게 변환하는 메서드
-    private String encodeFileName(String fileName) {
-        try {
-            return URLEncoder.encode(fileName, StandardCharsets.UTF_8.toString())
-                    .replaceAll("\\+", "%20"); // 공백 처리
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException("파일명 인코딩 오류", e);
-        }
+    // 안전한 파일명 변환 (특수 문자 제거)
+    private String sanitizeFileName(String fileName) {
+        return fileName.replaceAll("[\\\\/:*?\"<>|]", "_").replaceAll(" ", "_");
     }
 
+    public String generateCloudFrontUrl(String fileKey) {
+        return "https://" + cloudFrontDomain + "/" + fileKey;
+    }
+
+    public String extractOriginalFileName(String fileKey) {
+        return fileKey.substring(fileKey.lastIndexOf("/") + 1);
+    }
 
 }

--- a/src/main/java/com/hid_web/be/storage/community/NewsEventEntity.java
+++ b/src/main/java/com/hid_web/be/storage/community/NewsEventEntity.java
@@ -52,4 +52,5 @@ public class NewsEventEntity {
 
     @Column(nullable = false)
     private int views;
+
 }

--- a/src/main/java/com/hid_web/be/storage/community/NoticeEntity.java
+++ b/src/main/java/com/hid_web/be/storage/community/NoticeEntity.java
@@ -3,7 +3,6 @@ package com.hid_web.be.storage.community;
 import com.hid_web.be.domain.community.NoticeAuthorType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -15,7 +14,6 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class NoticeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
# Description
S3에 첨부파일을 저장할 때 UUID를 제거하고 원본 파일명으로 저장되도록 수정하였으며, 뉴스이벤트 삭제 시 썸네일이 S3에 남아있던 문제를 해결하였다.

# Todo
S3에 첨부파일을 업로드할 때 UUID_파일명이 아닌 원본 파일명 그대로 저장
뉴스이벤트 삭제 시 썸네일도 함께 S3에서 삭제되도록 로직 추가

closes #69 